### PR TITLE
Tidy up Java SE doc

### DIFF
--- a/ref/general/java-se.adoc
+++ b/ref/general/java-se.adoc
@@ -1,6 +1,3 @@
-// INSTRUCTION: Please remove all comments that start INSTRUCTION prior to commit. Most comments should be removed, although not the copyright.
-// INSTRUCTION: The copyright statement must appear at the top of the file
-//
 // Copyright (c) 2018 IBM Corporation and others.
 // Licensed under Creative Commons Attribution-NoDerivatives
 // 4.0 International (CC BY-ND 4.0)
@@ -12,29 +9,21 @@
 :page-layout: general-reference
 :page-type: general
 = Java SE support in Open Liberty
-// Choose a title that a developer would search for, given the subject of the article.
-// PAs of Liberty 18.0.0.4, you can use any version or distribution of Java SE 11.
 
-The developer kits include a Java Runtime Environment (JRE) and tools that you can use to develop, run, and monitor your Java applications. Java SE Developer Kit 8 and Java SE Developer Kit 11 are supported in Open Liberty. You can use any version or distribution of these versions. Because of changes in the Java SE platform that have occurred, zero-migration is not guaranteed.
+Open Liberty requires a Java SE runtime in order to run. A Java SE runtime (also known as a Java Runtime Environment, or a Java Developer Kit), provides the tools to develop, run and monitor your Java application. Open Liberty can run on any Java SE 8 compatible runtime, or the Java SE 11 runtimes listed below. Due to behaviour and API changes between Java SE 8 and Java SE 11 it is possible that an application that runs on Open Liberty/Java SE 8 may not run on Open Liberty/Java SE 11, see the https://docs.oracle.com/en/java/javase/11/migrate/index.html#JSMIG-GUID-C25E2B1D-6C24-4403-8540-CFEA875B994A[Oracle Java SE 11 migration guide] for more details.
+
+Open Liberty always recommends running the most recent release of Java available.
 
 == Java SE 8
 
-For the Java SDK from IBM, the minimum supported level is IBM SDK, Java Technology Edition, Version 8. For the JDK from Oracle, the minimum supported level is Java 8 update 25.
-
-On distributed platforms, 32-bit or 64-bit Java is supported. 
-
-For Windows and Linux systems, you can use either the JDK from Oracle or the Java SDK from IBM. If you are developing applications on Windows or Linux, and you plan to deploy those applications to a server that is running on WebSphere Application Server traditional, use the Java SDK from IBM. For HP systems and Mac OS, use the JDK from Oracle. 
+Any recent Java SE release from IBM, Oracle, AdoptOpenJDK will work. If using Oracle Java the minimum supported level if Java SE 8u25.
 
 == Java SE 11
 
-There are several Java 11 changes that impact Open Liberty. Between Java 8 and Java 11, several good enhancements such as local variables and the Flow API have been provided. However, there are also a few changes that are likely to cause problems for existing applications.
+Open Liberty currently only recommends the https://adoptopenjdk.net/index.html?variant=openjdk11&jvmVariant=openj9[OpenJDK 11 with OpenJ9 11.0.2] (or newer) release from AdoptOpenJDK. This is due to the following bugs we found in OpenJDK which are fixed in that release, but are not yet fixed in upstream OpenJDK:
 
-NOTE: Currently Open Liberty supports Java 11.0.2 (or newer) on the OpenJ9 VM. Other Java VMs, such as Hotspot, are not supported due to some outstanding VM bugs.
-
-In Java 11, several modules (groupings of Java packages) were removed from JDK. With the removal of Java EE and CORBA APIs from the JDK, it is important to note that your applications may have been relying on some these removed packages. However, all of the removed packages are already provided by existing Open Liberty features.
-
-The introduction of JPMS (Java Platform Module System) in Java 9 raised a major compatibility issue for most of the Java ecosystem because of restrictions affecting access between different Java modules. In Java SE 11, a "kill switch" (formally known as the --illegal-access=permit JVM option) has been introduced. It is enabled by default and allows code in unnamed modules to access and perform deep reflection on all named modules. It is important to note that eventually the kill switch will not be enabled by default, and later it will be removed entirely. So it is best to stop writing code that uses deep reflection and start migrating to alternative approaches.
-
+// Insert list of bugs 
+* https://bugs.openjdk.java.net/browse/JDK-8213202[JDK-8213202] Possible race condition in TLS 1.3 session resumption
 
 == See also
 


### PR DESCRIPTION
1. Update the intro to be more tied to the title. Remove references to distribution product names
2. Add link to the Java SE 8->11 documentation
3. Remove references to traditional WebSphere Application Server
4. Use 'recommended' rather than 'supported' for Java versions we tested with
5. Add link to the Java SE issue that prevented Liberty working well on hotspot
6. Remove all the template comments that should have been removed