### PR TITLE
Fix the Javadoc link to link to openliberty.io

### DIFF
--- a/ref/general/forwarded-header.adoc
+++ b/ref/general/forwarded-header.adoc
@@ -93,18 +93,18 @@ Verification or processing of these headers will only stop when a given node ide
 
 == Affected Servlet APIs and NCSA Access Log directives
 
-.https://javaee.github.io/javaee-spec/javadocs/javax/servlet/ServletRequest.html[ServletRequest] Java API:
+link:/docs/ref/javaee/8/#class=javax/servlet/ServletRequest.html&package=allclasses-frame.html[ServletRequest] Java API:
 * getRemoteAddr()
 * getRemoteHost()
 * getRemotePort()
 * getScheme()
 * isSecure()
 
-.NCSA Access Log directives:
+NCSA Access Log directives:
 * %a – Remote IP address
 * %h – Remote host name
 * %H – Request protocol
 
-For more information, see http://publib.boulder.ibm.com/httpserv/manual70/mod/mod_log_config.html[Apache Module mod_log_config] and https://www.ibm.com/support/knowledgecenter/SSAW57_9.0.0/com.ibm.websphere.nd.multiplatform.doc/ae/rrun_chain_httpcustom.html?view=embed#accesslogformat[accessLogFormat].
+For more information, see https://www.ibm.com/support/knowledgecenter/en/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/rwlp_http_accesslogs.html[HTTP access log settings].
 
 NOTE: These APIs and directives are only affected when the HTTP Channel is able to verify the remote client endpoint information.


### PR DESCRIPTION
OpenLiberty.io hosts the Javadoc for Java EE, but this page links elsewhere. Updating to link to this page.

Also having spoken to an Apache/IHS expert they suggested removing the link to the mod_log_config page.