### PR TITLE
See if we can feature link easily from reference doc to feature doc

### DIFF
--- a/ref/general/security-vulnerabilities.adoc
+++ b/ref/general/security-vulnerabilities.adoc
@@ -8,7 +8,7 @@
 //
 :page-layout: general-reference
 :page-type: general
-:seo-title: Open Liberty security vulnerability (CVEs) list - OpenLiberty.io. 
+:seo-title: Open Liberty security vulnerability (CVEs) list - OpenLiberty.io.
 :seo-description: A list of the CVEs that affect Open Liberty, ordered by the release in which they were fixed.
 = Security vulnerability (CVE) list
 
@@ -22,53 +22,53 @@ The following table lists the CVEs that affect Open Liberty, ordered by the rele
 |Privilege Escalation
 |17.0.0.3 - 18.0.0.3
 |18.0.0.4
-|Affects the ldapRegistry-3.0 feature
+|Affects the feature:ldapRegistry-3.0 feature
 
 |http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-7810[CVE-2014-7810]
 |5.0
 |Bypass Security
 |17.0.0.3 - 18.0.0.3
 |18.0.0.4
-|Affects the jsp-2.2, jsp-2.3 and el-3.0 features
+|Affects the feature:jsp-2.2, feature:jsp-2.3 and feature:el-3.0 features
 
 |http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-8039[CVE-2018-8039]
 |7.5
 |Man-in-the-Middle
 |17.0.0.3 - 18.0.0.2
 |18.0.0.3
-|Affects the jaxws-2.2, jaxrs-2.0 and jaxrs-2.1 features
+|Affects the feature:jaxws-2.2, feature:jaxrs-2.0 and feature:jaxrs-2.1 features
 
 |http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1755[CVE-2018-1755]
 |5.9
 |Information Disclosure
 |17.0.0.3 - 18.0.0.2
 |18.0.0.3
-|Affects the jaspic-1.0 feature 
+|Affects the feature:jaspic-1.0 feature
 
 |http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1683[CVE-2018-1683]
 |5.9
 |Information Disclosure
 |17.0.0.3 - 18.0.0.2
 |18.0.0.3
-|Affects the ejbRemote-3.2 feature
+|Affects the feature:ejbRemote-3.2 feature
 
 |http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-12624[CVE-2017-12624]
 |5.3
 |Denial of Service
 |17.0.0.3 - 17.0.0.4
 |18.0.0.1
-|Affects the jaxws-2.2, jaxrs-2.0 and jaxrs-2.1 features
+|Affects the feature:jaxws-2.2, feature:jaxrs-2.0 and feature:jaxrs-2.1 features
 
 |http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-1788[CVE-2017-1788]
 |5.3
 |Spoofing
 |17.0.0.3 - 17.0.0.4
 |18.0.0.1
-|Any feature that enables security. e.g. appSecurity-1.0-3.0, restConnector-2.0.
+|Any feature that enables security. e.g. feature:appSecurity-2.0 feature:appSecurity-3.0, feature:restConnector-2.0.
 
 |http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-1000031[CVE-2016-100031]
 |9.8
 |Execute Code
 |17.0.0.3 - 17.0.0.4
 |18.0.0.1
-|Affects the servlet-3.1 and servlet-4.0 features
+|Affects the feature:servlet-3.1 and feature:servlet-4.0 features


### PR DESCRIPTION
In theory if you add feature: to the start of a feature name we will generate
a cross link to the feature doc. This works for feature doc to config doc,
but we haven't tried it outside that context, so this is an experiment to see
if it works generally.