### PR TITLE
Add .html to the guides links

### DIFF
--- a/ref/general/microprofile.adoc
+++ b/ref/general/microprofile.adoc
@@ -38,12 +38,12 @@ The vast majority of cloud-native microservices are based on REST APIs, making t
 === Build REST services
 The JAX-RS, CDI, JSON-B, and JSON-P Java EE technologies provide the base for MicroProfile. If you're new to Java EE and MicroProfile, this is a good place to start. JAX-RS is a Java API that allows you to build REST APIs by creating resource classes and adding appropriate annotations to create the necessary web endpoints. Context and Dependency Injection (CDI) provides objects with the dependencies that they need through the `@Inject` annotation rather than directly creating an object or finding them using a factory. JSON-P and JSON-B make it easy to automatically serialize and deserialize classes to and from JSON.
 
-Try it now: Learn how to create a REST service with JAX-RS, JSON-P, and Open Liberty in our guide to link:/guides/rest-intro[Creating a RESTful web service].
+Try it now: Learn how to create a REST service with JAX-RS, JSON-P, and Open Liberty in our guide to link:/guides/rest-intro.html[Creating a RESTful web service].
 
 === Consume a REST service with type-safe Java
 MicroProfile Rest Client provides a type-safe approach for invoking REST services over HTTP. This API greatly simplifies the client-side API as defined by JAX-RS. MicroProfile Rest Client handles the communication between the client and service. You only need to define and annotate an interface that describes the actions that you need to perform on a REST resource. An implementation of this interface is automatically generated for you when CDI is used to inject your client into a dependent class.
 
-Try it now: Learn how to use MicroProfile Rest Client to invoke RESTful microservices over HTTP in a type-safe way in our guide to link:/guides/microprofile-rest-client[Consuming RESTful services with template interfaces].
+Try it now: Learn how to use MicroProfile Rest Client to invoke RESTful microservices over HTTP in a type-safe way in our guide to link:/guides/microprofile-rest-client.html[Consuming RESTful services with template interfaces].
 
 === Implement reactive programming for microservices
 MicroProfile Reactive Streams Operators provides a way to implement publish/subscribe pipelines that provide flow control and elegant error handling for asynchronous data streams. This implementation enables the processing of streams of data without publishers overwhelming downstream subscribers. Reactive Streams Operators can increase efficiency under potentially overloading conditions by using a ticketing system that creates 'back pressure' between the publisher and subscriber. Because you can directly connect publishers and subscribers regardless of underlying technology, Reactive Streams Operators serves as an abstraction that can efficiently bind together different technologies.
@@ -57,30 +57,30 @@ Handling hundreds of autonomous, collaborating, and frequently evolving services
 === Document your REST APIs
 MicroProfile OpenAPI provides a Java API for the OpenAPI specification that you can use to expose API documentation for your REST APIs.  You can natively produce OpenAPI documents from your JAX-RS applications. OpenAPI is a standardization of https://swagger.io/blog/difference-between-swagger-and-openapi/[the Swagger specification].
 
-Try it now: Explore how to document and filter RESTful APIs by using MicroProfile OpenAPI in our guide to link:/guides/microprofile-openapi[Documenting RESTful APIs].
+Try it now: Explore how to document and filter RESTful APIs by using MicroProfile OpenAPI in our guide to link:/guides/microprofile-openapi.html[Documenting RESTful APIs].
 
 === Handle unexpected failures in your microservices
 MicroProfile Fault Tolerance provides an API and annotations for building robust behavior to cope with unexpected failures in the service you depend on. Aspects of fault tolerance include timeouts, retries, fallbacks, bulkhead processing, and circuit breakers.
 
 Try it now: Explore how to manage the impact of failures by using MicroProfile Fault Tolerance in the following guides, written by our team:
 
-- link:/guides/microprofile-fallback[Building fault-tolerant microservices with the @Fallback annotation]
-- link:/guides/retry-timeout[Failing fast and recovering from errors]
-- link:/guides/circuit-breaker[Preventing repeated failed calls to microservices]
-- link:/guides/bulkhead[Limiting the number of concurrent requests to microservices]
+- link:/guides/microprofile-fallback.html[Building fault-tolerant microservices with the @Fallback annotation]
+- link:/guides/retry-timeout.html[Failing fast and recovering from errors]
+- link:/guides/circuit-breaker.html[Preventing repeated failed calls to microservices]
+- link:/guides/bulkhead.html[Limiting the number of concurrent requests to microservices]
 
 === Manage authentication and role-based access control
 MicroProfile JSON Web Token (JWT) provides for interoperable authentication and role-based access control for your services.  It allows an authenticated JWT token to be shared across multiple microservices even if these services are running on multiple vendor implementations. It also allows access to microservice operations to be controlled based on user and role information passed within the JWT token.
 
-Try it now: Explore how to control user and role access to microservices with MicroProfile JWT in our guide to link:/guides/microprofile-jwt[Securing microservices with JSON Web Tokens].
+Try it now: Explore how to control user and role access to microservices with MicroProfile JWT in our guide to link:/guides/microprofile-jwt.html[Securing microservices with JSON Web Tokens].
 
 === Externalize configuration to improve portability
 MicroProfile Config externalizes configuration from the application to improve portability of the application. A core principle is to be able to override configuration at deployment time using system properties and environment variables. This means you can build your microservice once and deploy it many times through your CI/CD pipeline by changing the configuration for each deployment.
 
 Try it now: Learn how to configure microservices using MicroProfile Config in these guides, written by our team:
 
-- link:/guides/microprofile-config[Configuring microservices]
-- link:/guides/microprofile-config-intro[Separating configuration from code in microservices]
+- link:/guides/microprofile-config.html[Configuring microservices]
+- link:/guides/microprofile-config-intro.html[Separating configuration from code in microservices]
 
 // Top layer
 == MicroProfile helps you write observable microservices
@@ -92,19 +92,19 @@ MicroProfile Health Check provides a common REST endpoint format to determine wh
 
 Try it now: Explore how to report and check the health of a microservice with MicroProfile Health in these guides, written by our team:
 
-- link:/guides/microprofile-health[Adding health reports to microservices].
+- link:/guides/microprofile-health.html[Adding health reports to microservices].
 
-- link:/guides/kubernetes-microprofile-health[Checking the health of microservices on Kubernetes].
+- link:/guides/kubernetes-microprofile-health.html[Checking the health of microservices on Kubernetes].
 
 === Monitor a microservice's telemetry data
 MicroProfile Metrics provides common REST endpoints for monitoring the telemetry data of a running microservice, similar in nature to JMX, but a much simpler API that uses JAX-RS.  Both built-in and application-defined metrics are accessible, with the output in either JSON or Prometheus text formats. This API provides more extensive detail than the simple up and down reporting provided by MicroProfile Health.
 
-Try it now: Explore how to provide system and application metrics from a microservice with MicroProfile Metrics in our guide to link:/guides/microprofile-metrics[Providing metrics from a microservice].
+Try it now: Explore how to provide system and application metrics from a microservice with MicroProfile Metrics in our guide to link:/guides/microprofile-metrics.html[Providing metrics from a microservice].
 
 === Enable distributed tracing of your microservices
 MicroProfile OpenTracing allows services to easily participate in a distributed tracing environment.  OpenTracing defines behaviors and an API for accessing an http://opentracing.io/[OpenTracing]-compliant Tracer object within your microservice.  These trace logs can then be consumed by a third-party distributed tracing facility such as https://zipkin.io/[Zipkin] or https://github.com/jaegertracing/jaeger[Jaeger].
 
-Try it now: Explore how to enable and customize tracing of JAX-RS and non-JAX-RS methods by using MicroProfile OpenTracing in our guide to link:/guides/microprofile-opentracing[Enabling distributed tracing in microservices].
+Try it now: Explore how to enable and customize tracing of JAX-RS and non-JAX-RS methods by using MicroProfile OpenTracing in our guide to link:/guides/microprofile-opentracing.html[Enabling distributed tracing in microservices].
 
 == Where to next?
 


### PR DESCRIPTION
https://openliberty.io/docs/ref/general/#microprofile.html has a few links to other guides, for example:

https://openliberty.io/guides/rest-intro however this links gives 404 because it doesn't have ".html".
The correct addess is https://openliberty.io/guides/rest-intro.html.

All other pages have .html:
```
grep -oe ':\/guides\/.*\[' *.adoc                                                                                                                                                                                                                                                                                                                  ref/general|docs
cloud_native_microservices.adoc::/guides/microprofile-config-intro.html[
cloud_native_microservices.adoc::/guides/retry-timeout.html[
cloud_native_microservices.adoc::/guides/?search=microprofile&key=tag[
health-check-microservices.adoc::/guides/microprofile-health[Adding health reports to microservices] and link:/guides/kubernetes-microprofile-health[
metrics-catalog.adoc::/guides/microprofile-metrics.html[
==========Only microprofile has links without extension====================
microprofile.adoc::/guides/rest-intro[
microprofile.adoc::/guides/microprofile-rest-client[
microprofile.adoc::/guides/microprofile-openapi[
microprofile.adoc::/guides/microprofile-fallback[
microprofile.adoc::/guides/retry-timeout[
microprofile.adoc::/guides/circuit-breaker[
microprofile.adoc::/guides/bulkhead[
microprofile.adoc::/guides/microprofile-jwt[
microprofile.adoc::/guides/microprofile-config[
microprofile.adoc::/guides/microprofile-config-intro[
microprofile.adoc::/guides/microprofile-health[
microprofile.adoc::/guides/kubernetes-microprofile-health[
microprofile.adoc::/guides/microprofile-metrics[
microprofile.adoc::/guides/microprofile-opentracing[
=========================================================================
microservice_observability_metrics.adoc::/guides/microprofile-metrics.html[
rest_clients.adoc::/guides/microprofile-rest-client.html[
rest_microservices.adoc::/guides/microprofile-openapi.html[
sync_async_rest_clients.adoc::/guides/microprofile-rest-client.html[
```