### PR TITLE
Fixes 'shared.config.dir' description

### DIFF
--- a/ref/config/serverConfiguration.adoc
+++ b/ref/config/serverConfiguration.adoc
@@ -233,7 +233,7 @@ There are a number of predefined variables:
   `${wlp.install.dir}/usr`.
 * `shared.app.dir` - the location of shared applications. Defaults to
   `${wlp.user.dir}/shared/apps`.
-* `shared.config.dir` - the directory that contains the server config. Defaults to
+* `shared.config.dir` - the location of shared configuration files. Defaults to
   `${wlp.user.dir}/shared/config`.
 * `shared.resource.dir` - the location of shared resource files. Defaults to
   `${wlp.user.dir}/shared/resources`.


### PR DESCRIPTION
The description of:
> `shared.config.dir` - the directory that contains the server config....

seems too similar to:
> `server.config.dir` - the directory that server config is stored in.

Went back to [this](https://www.ibm.com/support/knowledgecenter/en/SS7K4U_liberty/com.ibm.websphere.wlp.zseries.doc/ae/rwlp_dirs.html) article, for this (IMHO) better phrasing.