### PR TITLE
Add example for `webTarget` configuration in JAXRS

### DIFF
--- a/ref/feature/examples/webTarget.examples
+++ b/ref/feature/examples/webTarget.examples
@@ -1,0 +1,48 @@
+== Examples
+
+=== Override JAX-RS Client configuration example
+The JAX-RS Client APIs allow users to specify properties on the client that configure settings like timeouts, proxy
+hosts, SSL properties, etc. If the application is deployed in a different environment, these settings may need to
+change. For example, suppose the application is coded for a development environment, where all remote RESTful services
+are available without a proxy server and can connect very quickly. The application may be coded as such:
+
+[source,java]
+----
+public Widget getRemoteWidget(String id) {
+    Client client = ClientBuilder.newClient();
+    WebTarget target = client.target("https://somehost:9443/WidgetStore/widgets/");
+    target.property("com.ibm.ws.jaxrs.client.connection.timeout", 5000); // 5 seconds
+    target.property("myCustomProperty", "dev");
+    Widget widget = target.path(id).request().get(Widget.class);
+    return widget;
+}
+----
+
+When this application is deployed in a production environment, it may be necessary to modify these settings. This can
+be accomplished by adding the following configuration to the server config:
+
+[source,xml]
+----
+<webTarget uri="https://somehost:9443/WidgetStore*" proxyHost="myProxyHost" proxyPort="55555" proxyType="HTTP"
+           connectionTimeout="30000" receiveTimeout="30000" />
+----
+
+This will alter the `WebTarget` in the Java code to use the specified HTTP proxy server (myProxyHost:55555) and use
+connection and receive timeouts of 30 seconds (30,000 milliseconds).
+
+The request could be further modified to use a specified SSL configuration or to disable hostname verification of SSL
+certificates (not recommended in production environments). You can  or update a custom property:
+
+[source,xml]
+----
+<webTarget uri="https://somehost:9443/WidgetStore*" sslConfig="mySSLRef" disableCNCheck="true" />
+----
+
+You can also specify custom properties for the `WebTarget`:
+
+[source,xml]
+----
+<webTarget uri="https://somehost:9443/WidgetStore*" myCustomProperty="prod" />
+----
+
+The complete list of pre-defined properties is available here: config:webTarget[]

--- a/ref/feature/jaxrsClient-2.0.adoc
+++ b/ref/feature/jaxrsClient-2.0.adoc
@@ -7,6 +7,8 @@ include::./gen/jaxrsClient-2.0.gendoc[tag=description]
 
 include::./gen/jaxrsClient-2.0.gendoc[tag=enable]
 
+include::./examples/webTarget.examples[]
+
 include::./gen/jaxrsClient-2.0.gendoc[tag=config]
 
 include::./gen/jaxrsClient-2.0.gendoc[tag=apis]

--- a/ref/feature/jaxrsClient-2.1.adoc
+++ b/ref/feature/jaxrsClient-2.1.adoc
@@ -7,6 +7,8 @@ include::./gen/jaxrsClient-2.1.gendoc[tag=description]
 
 include::./gen/jaxrsClient-2.1.gendoc[tag=enable]
 
+include::./examples/webTarget.examples[]
+
 include::./gen/jaxrsClient-2.1.gendoc[tag=config]
 
 include::./gen/jaxrsClient-2.1.gendoc[tag=apis]


### PR DESCRIPTION
Adding new examples section to `jaxrsClient-2.0` and `jaxrsClient-2.1` feature pages.  