### PR TITLE
updates per SME review

### DIFF
--- a/ref/general/LDAP-registry.adoc
+++ b/ref/general/LDAP-registry.adoc
@@ -6,7 +6,8 @@
 // Contributors:
 //     IBM Corporation
 //
-:page-description:
+:page-description: You can configure an LDAP user registry to manage authentication and authorization for your applications that run on Open Liberty.
+:page-layout: general-reference
 :seo-title: Configuring an LDAP user registry for authentication and authorization
 :seo-description: You can configure an LDAP user registry to manage authentication and authorization for your applications that run on Open Liberty.
 :page-layout: general-reference
@@ -21,9 +22,9 @@ You can configure Open Liberty to retrieve security information from an LDAP ser
 
 == Configuring an LDAP registry with Open Liberty
 
-To use an existing LDAP server as a user registry, first add the link:/docs/ref/feature/#appSecurity-3.0.html[Application Security] and link:/docs/ref/config/#ldapRegistry.html[LDAP User Registry] features to your `server.xml` file. If you need to communicate with an SSL-enabled LDAP server, you must also add the link:/docs/ref/feature/#transportSecurity-1.0.html[Transport Security] feature.
+To use an existing LDAP server as a user registry, first add the link:/docs/ref/feature/#appSecurity-3.0.html[Application Security] and link:/docs/ref/feature/#ldapRegistry-3.0.html[LDAP User Registry] features to your `server.xml` file. If you need to communicate with an SSL-enabled LDAP server, you must also add the link:/docs/ref/feature/#transportSecurity-1.0.html[Transport Security] feature.
 
-Configure the LDAP user registry by adding the `<ldapregistry>` element to your `server.xml` file. Then, specify the port number, the host DNS name or IP address, LDAP type, and other attributes, as required by your security configuration. The following example shows a simple configuration for using IBM's Security Directory server as an LDAP registry:
+Configure the LDAP user registry by adding the `<ldapRegistry>` element to your `server.xml` file. Then, specify the port number, the host DNS name or IP address, LDAP type, and other attributes, as required by your security configuration. The following example shows a simple configuration for using IBM's Security Directory server as an LDAP registry:
 
 [source,java]
 ----
@@ -34,15 +35,16 @@ Configure the LDAP user registry by adding the `<ldapregistry>` element to your 
       ldapType="IBM Security Directory Server" searchTimeout="8m">
 </ldapRegistry>
 ----
-For a full list of configuration elements and attributes, see the link:/docs/ref/config/#ldapRegistry.html[LDAP User Registry feature].
+For a full list of configuration elements and attributes, see the link:/docs/ref/config/#ldapRegistry.html[LDAP User Registry configuration].
 
 
 == Federated LDAP registries
-You can also federate LDAP user registries so that multiple registries can be referenced together from a local view. You can federate LDAP registries with one another or with custom and basic user registries. For more information, see Federating user registries (link pending).
+LDAP registries are federated by default. If you configure more than one LDAP registry in your server.xml file, then the registries are automatically federated with no additional configuration required. LDAP registries can be federated with one another or with custom and basic user registries. For more information, see link:/docs/ref/general/#federated-registries.html[Federating user registries].
 
 == Using the Social Media Login feature with LDAP registries
 
 You can use Open Liberty's Social Media Login feature to help manage authentication with a configured LDAP registry. Depending how you configure the feature, users can either supply their social media credentials to authenticate to the LDAP registry or choose between their LDAP sign in and social media credentials for authentication. For more information, see the example configurations for the link:/docs/ref/feature/#socialLogin-1.0.html[Social Media Login feature].
+
 
 == LDAP certificate map mode
 


### PR DESCRIPTION
Updates per @jvanhill slack review:
- The LDAP User Registry link points to the config instead of the feature, like the Application Security and Transport Security links do. **FIXED**
- The ldapregistry element should be ldapRegistry **FIXED**
- Change "see the LDAP User Registry feature" to "see the LDAP User Registry configuration" **FIXED**
- LDAP registries are federated automatically. Should probably mention it here. **UPDATED**
- The link under CUSTOM certificate map mode is bad. **this link works on my end. Not sure why it failed in review**