### PR TITLE
edits per SME review

### DIFF
--- a/ref/general/federated-registries.adoc
+++ b/ref/general/federated-registries.adoc
@@ -13,9 +13,9 @@
 :page-type: general
 = Federating user registries
 
-You can combine multiple user registries into a single federated registry to manage authentication and authorization for your application.
+You can combine multiple user registries into a single federated registry to manage authentication and authorization for your application. Federated registries provide a single logical view of multiple user registries and repositories.
 
-In cases where user and group information is spread across multiple registries, federation enables Open Liberty to use this distributed user information in a unified manner with continuous store of information. Different types of registries can be federated to combine information from Lightweight Directory Access Protocol (LDAP), basic, and custom user registries into a common registry to manage application security. However, user registries that are configured with the `quickStartSecurity` element cannot be federated with other registries.
+In cases where user and group information is spread across multiple registries, federation enables Open Liberty to use this distributed user information in a unified manner with continuous store of information. Different types of registries can be federated to combine information from Lightweight Directory Access Protocol (LDAP), basic, and custom user registries  and repositories into a common registry to manage application security. However, user registries that are configured with the `quickStartSecurity` element cannot be federated with other registries.
 
 == Federation of LDAP registries
 
@@ -30,9 +30,8 @@ The following example shows a basic registry federated with an LDAP registry, wi
 ----
 <server description="Federation">
     <featureManager>
-        <feature>appSecurity-2.0</feature>
-        <feature>servlet-3.0</feature>
-	 <feature>ldapRegistry-3.0</feature>
+        <feature>appSecurity-3.0</feature>
+	      <feature>ldapRegistry-3.0</feature>
     </featureManager>
 
     <basicRegistry id="basic" realm="SampleBasicRealm">
@@ -49,15 +48,12 @@ The following example shows a basic registry federated with an LDAP registry, wi
         </group>
     </basicRegistry>
 
-    <ldapRegistry id="LDAP1" realm="SampleLdapIDSRealm" host="LDAPHOST1.ibm.com" port="389" ignoreCase="true"
+    <ldapRegistry realm="LdapRealm" host="LDAPHOST1.ibm.com" port="389"
 	baseDN="o=ibm,c=us"
-	ldapType="IBM Security Directory Server"
-	searchTimeout="8m"
-	recursiveSearch="true">
-    </ldapRegistry>
+	ldapType="IBM Security Directory Server"/>
 
     <federatedRepository>
-        <primaryRealm name="PrimaryRealm" allowOpIfRepoDown="true">
+        <primaryRealm name="FederatedRealm" allowOpIfRepoDown="true">
             <participatingBaseEntry name="o=SampleBasicRealm"/>
             <participatingBaseEntry name="o=ibm,c=us"/>
         </primaryRealm>
@@ -73,7 +69,7 @@ To federate two or more basic registries, you must enable both link:/docs/ref/fe
 ----
 <server description="Federation">
     <featureManager>
-        <feature>appSecurity-2.0</feature>
+        <feature>appSecurity-3.0</feature>
         <feature>federatedRegistry-1.0</feature>
     </featureManager>
 
@@ -103,7 +99,9 @@ To federate two or more basic registries, you must enable both link:/docs/ref/fe
 </server>
 ----
 
-You can add basic or custom registries to a custom federated repository by defining the `participatingBaseEntry` name field in the `federatedRepository` element. The participating base entry for a custom or basic registry is the organization attribute set to the realm name of that registry. The following example shows the federation of a basic registry and a custom registry:
+You can add basic or custom registries to a custom federated repository by defining the `participatingBaseEntry` name field in the `federatedRepository` element. The participating base entry for a custom or basic registry is the `o` organization attribute set to equal the realm name of that registry (`"o=RealmName"`). The realm name for a user registry is the value that is returned from the `getRealm(`) method of that registry. For an LDAP registry, the realm name is the base Distinguished Name (`baseDN`) from the registry configuration. The participating base entry for a custom repository is one of the base entries that is returned by the `getRepositoryBaseEntries()` method for that repository. 
+
+The following example shows the federation of a basic registry and a custom registry:
 
 [source,java]
 ----


### PR DESCRIPTION
Edits per @jvanhill slack review:

I would describe federated registries as a single logical view of multiple user registries and/or repositories
- Can also federate CustomRepositories. **UPDATED**
- use appSecurity-3.0 in your config examples (latest). **UPDATED**
- I would remove all but the necessary config for LDAP (remove id, ignoreCase, serchTimeout, recursiveSearch, and you can get rid of the </ldapRegistry> element if you close the opening element. **UPDATED**
- Also remove the unnecessary features: servlet-3.0 **UPDATED**
- When federating, i like to name realms so they are obvious in trace, i.e. LdapRealm, BasicRealm, FederatedRealm **UPDATED**
- I would clarify the "organization attribute set to the realm name of that registry". Maybe something like "The participating base entry for a UserRegistry (basic, custom or SAF) is "o=" + the value returned from the getRealm() method of the user registry. **edited to clarify this section, lmk if it needs more tweaking to be clear**
- For LDAP, it is the "baseDN" from the configuration. ****UPDATED**
- For CustomRepository's it is one of the base entries returned by the getRepositoryBaseEntries() method. **UPDATED**