### PR TITLE
push the new dir structure for config snippets and social media login example 

### DIFF
--- a/ref/feature/audit-1.0.adoc
+++ b/ref/feature/audit-1.0.adoc
@@ -7,6 +7,8 @@ include::./gen/audit-1.0.gendoc[tag=description]
 
 include::./gen/audit-1.0.gendoc[tag=enable]
 
+//include::./audit/examples.adoc[]
+
 include::./gen/audit-1.0.gendoc[tag=config]
 
 include::./gen/audit-1.0.gendoc[tag=apis]

--- a/ref/feature/audit/description.adoc
+++ b/ref/feature/audit/description.adoc
@@ -1,0 +1,6 @@
+The Audit feature introduces an infrastructure that serves two purposes:
+ - Confirming the effectiveness and integrity of the existing configuration
+ - Identifying areas where improvement to the configuration may be needed
+
+The Audit feature can capture a range of auditable events, including
+events related to authentication, authorization, and logout. The feature provides a default implementation, the AuditFileHandler, which emits human-readable audit records to a file-based log. Each audit record is emitted in JSON format.

--- a/ref/feature/audit/examples.adoc
+++ b/ref/feature/audit/examples.adoc
@@ -1,0 +1,80 @@
+== Examples
+
+=== Audit File Handler
+
+The audit file handler is made available by specifying the audit-1.0 feature. It can be customized by specifying any of the config attributes, along with the <auditFileHandler> element. For more information, see link:https://www.openliberty.io/docs/ref/config/#auditFileHandler.html[Default Audit File Handler].
+
+When the maximum number of archived audit logs is reached, after the audit.log file that is being written to reaches its maximum size, then the oldest archived audit log is overwritten.
+
+The following example shows an Audit file handler with maxFiles, maxFileSize, and compact mode specified:
+
+[source,xml]
+----
+<featureManager>
+    <feature>appSecurity-2.0</feature>
+    <feature>[.underline]#jsp#-2.2</feature>
+    <feature>[.underline]#servlet#-3.1</feature>
+    <feature>audit-1.0</feature>
+    <feature>[.underline]#timedexit#-1.0</feature>
+</featureManager>
+
+<auditFileHandler maxFiles="50" maxFileSize="100" compact=”true”>
+</auditFileHandler>
+----
+
+In the example, the audit logs are written to the default $\{server.output.dir}/logs directory. Each audit file has a maximum 100 MB size before they are archived and new audit records are written to a new audit.log file. The maximum number of archived audit logs is 50. Once 50 audit logs are archived, and the current audit.log file that is written to reaches the 100 MB size, then the oldest archived audit.log file is overwritten.
+
+All audit events and possible outcomes are emitted to the audit logs.
+
+=== Events
+
+To specify only those audit events and outcomes that may be of relevance in an environment, the <event> element can be defined with the audit event name and outcome:
+
+The following example specifies audit events and outcomes:
+
+----
+<featureManager>
+    <feature>appSecurity-2.0</feature>
+    <feature>[.underline]#servlet#-4.0</feature>
+    <feature>audit-1.0</feature>
+</featureManager>
+
+<auditFileHandler maxFiles="5" maxFileSize="20" compact="true">
+    <events name="AuditEvent_1" eventName="SECURITY_AUTHN" outcome="SUCCESS"/>
+    <events name="AuditEvent_2" eventName="SECURITY_AUTHN" outcome="REDIRECT"/>
+    <events name="AuditEvent_3" eventName="SECURITY_AUTHN" outcome="FAILURE"/>
+    <events name="AuditEvent_4" eventName="SECURITY_AUTHZ"/>
+</auditFileHandler>
+----
+
+In the example, only the security authentication events whose outcome is success, redirect, or failure, and security authorization events whose outcome includes all supported outcomes are captured.
+
+If an event is specified with only an outcome attribute, with no eventName specified, then no audit records are produced. However, an eventName can be specified without an outcome attribute, in which case all possible outcomes for that eventName are emitted.
+
+=== Encrypting and Signing Audit
+
+It is important for the recorded audit data to be preserved in such a way that not only can the access be restricted but also so that the data itself is tamper-proof. The ability to both encrypt and sign the audit records data is provided.
+
+To encrypt audit records, the encrypt attribute must be specified in the auditFileHandler element, along with the alias name of the certificate that is used to encrypt the audit data, and the keystore in which that certificate exists.
+
+To sign audit records, the sign attribute must be specified in the auditFileHandler element, along with the alias name of the certificate that is used to sign the audit data, and the keystore in which that certificate exists.
+
+SHA256withRSA is used as the default crypto algorithm for both encryption and signing. The following example shows the audit file handler with encryption and signing enabled:
+
+----
+<featureManager>
+    <feature>appSecurity-2.0</feature>
+    <feature>[.underline]#jsp#-2.2</feature>
+    <feature>[.underline]#servlet#-3.1</feature>
+    <feature>audit-1.0</feature>
+</featureManager>
+
+<keyStore id="auditEncKeyStore” password="Liberty" location="$\{server.config.dir}/resources/security/AuditEncryptionKeyStore.jks" type="JKS" />
+
+<keyStore id="auditSignKeyStore" password="\{[.underline]#xor#}EzY9Oi0rJg==" location="$\{server.config.dir}/resources/security/AuditSigningKeyStore2.[.underline]#jks#" type="JKS" />
+
+<auditFileHandler encrypt="true" encryptAlias="[.underline]#auditencryption#" encryptKeyStoreRef="auditEncKeyStore" sign="true" signingAlias="auditsigning2" signingKeyStoreRef="auditSignKeyStore"
+</auditFileHandler>
+----
+
+All audit events and possible outcomes are emitted to the audit logs.

--- a/ref/feature/jdbc-4.0.adoc
+++ b/ref/feature/jdbc-4.0.adoc
@@ -7,7 +7,7 @@ include::./gen/jdbc-4.0.gendoc[tag=description]
 
 include::./gen/jdbc-4.0.gendoc[tag=enable]
 
-include::./examples/jdbc.examples[]
+include::./jdbc/examples.adoc[]
 
 include::./gen/jdbc-4.0.gendoc[tag=config]
 

--- a/ref/feature/jdbc-4.1.adoc
+++ b/ref/feature/jdbc-4.1.adoc
@@ -7,7 +7,7 @@ include::./gen/jdbc-4.1.gendoc[tag=description]
 
 include::./gen/jdbc-4.1.gendoc[tag=enable]
 
-include::./examples/jdbc.examples[]
+include::./jdbc/examples.adoc[]
 
 include::./gen/jdbc-4.1.gendoc[tag=config]
 

--- a/ref/feature/jdbc-4.2.adoc
+++ b/ref/feature/jdbc-4.2.adoc
@@ -7,7 +7,7 @@ include::./gen/jdbc-4.2.gendoc[tag=description]
 
 include::./gen/jdbc-4.2.gendoc[tag=enable]
 
-include::./examples/jdbc.examples[]
+include::./jdbc/examples.adoc[]
 
 include::./gen/jdbc-4.2.gendoc[tag=config]
 

--- a/ref/feature/jdbc-4.3.adoc
+++ b/ref/feature/jdbc-4.3.adoc
@@ -7,7 +7,7 @@ include::./gen/jdbc-4.3.gendoc[tag=description]
 
 include::./gen/jdbc-4.3.gendoc[tag=enable]
 
-include::./examples/jdbc.examples[]
+include::./jdbc/examples.adoc[]
 
 include::./gen/jdbc-4.3.gendoc[tag=config]
 

--- a/ref/feature/jdbc/examples.adoc
+++ b/ref/feature/jdbc/examples.adoc
@@ -1,0 +1,75 @@
+== Examples
+
+=== Simple DataSource example
+To configure a data source, two configuration elements are typically required:
+
+1. Shared library containing JDBC driver file(s)
+2. One or more data source elements using the the shared library
+
+The following example creates a data source that can be injected using the name `jdbc/myDataSource`. If the feature:jndi-1.0[] feature is enabled, that name can be used as a JNDI name:
+
+[source,xml]
+----
+<library id="JdbcLib">
+    <fileset dir="${server.config.dir}/jdbc"/>
+</library>
+
+<dataSource jndiName="jdbc/myDataSource">
+   <jdbcDriver libraryRef="JdbcLib"/>
+   <properties databaseName="myDB" serverName="mydb.mycompany.com" portNumber="50000"/>
+</dataSource>
+----
+
+A Servlet or EJB can then get it injected for use:
+
+[source,java]
+----
+@Resource(name="jdbc/myDataSource")
+private DataSource myDb;
+
+public void insertRochester() throws SQLException {
+    try (Connection con = myDataSource.getConnection()) {
+       con.createStatement().executeUpdate("INSERT INTO CITIES VALUES('Rochester', 'MN', 'US')");
+    }
+}
+----
+
+=== DataSource with authentication
+
+When connecting to remote databases, credentials typically need to be provided.
+These can be configured using an `authData` element. The password can be in
+plain text, xor, or aes encrypted. The `securityUtility encode` command can be
+used to create an encoded password. The following example encodes `password` as the
+password value:
+
+[source,xml]
+----
+<authData id="dbCreds" user="dbUser" password="{aes}AEJrzAGfDEmtxI18U/qEcv54kXmUIgUUV7b5pybw/BzH" />
+
+<dataSource jndiName="jdbc/myDataSource" containerAuthDataRef="dbCreds">
+   <jdbcDriver libraryRef="JdbcLib"/>
+   <properties databaseName="myDB" serverName="mydb.mycompany.com" portNumber="50000"/>
+</dataSource>
+----
+
+=== Using JDBC driver classes from an application
+
+Some applications make use of JDBC driver classes using `Connection.unwrap`. This
+means the application needs to be able to view the JDBC driver classes. This is
+done by configuring the application classloader to see the JDBC driver classes:
+
+[source,xml]
+----
+<library id="JdbcLib">
+    <fileset dir="${server.config.dir}/jdbc"/>
+</library>
+
+<webApplication location="myweb.war" >
+    <classloader commonLibraryRef="JdbcLib" />
+</webApplication>
+
+<dataSource jndiName="jdbc/myDataSource">
+   <jdbcDriver libraryRef="JdbcLib"/>
+   <properties databaseName="myDB" serverName="mydb.mycompany.com" portNumber="50000"/>
+</dataSource>
+----

--- a/ref/feature/socialLogin-1.0.adoc
+++ b/ref/feature/socialLogin-1.0.adoc
@@ -5,7 +5,11 @@
 
 include::./gen/socialLogin-1.0.gendoc[tag=description]
 
+include::./socialLogin/description.adoc[]
+
 include::./gen/socialLogin-1.0.gendoc[tag=enable]
+
+include::./socialLogin/examples.adoc[]
 
 include::./gen/socialLogin-1.0.gendoc[tag=config]
 

--- a/ref/feature/socialLogin/description.adoc
+++ b/ref/feature/socialLogin/description.adoc
@@ -1,0 +1,1 @@
+For example, you can configure the Social Login feature so that users can log in to your website with their Facebook or Twitter accounts instead of having to create an account specifically for your website. You can enable the Social Login feature for any social media platform that uses the OAuth 2.0 or OpenID Connect 1.0 standard for authorization.

--- a/ref/feature/socialLogin/examples.adoc
+++ b/ref/feature/socialLogin/examples.adoc
@@ -1,0 +1,117 @@
+== Examples
+
+You can require that users log in with a specific social media provider, or you can give them a list of providers so that they can choose which they prefer to log in with. You can also restrict when they have certain log in options based on browser type, the application, and so on. The following examples show how to configure different scenarios in your `server.xml`.
+
+=== Request log in with a social media ID
+
+A customizable selection form is presented so the user can choose which provider they prefer to sign in with. The following example shows how to configure your application to request that the user logs in with their Google ID:
+
+[source,xml]
+----
+<googleLogin clientId="your_app_id" clientSecret="your_app_secret"  />
+
+<!-- protected apps need to have a security constraint defined -->
+<application type="war" id="formlogin" name="formlogin" location="${server.config.dir}/apps/formlogin.war">
+    <application-bnd>         
+        <security-role name="Employee">
+            <special-subject type="ALL_AUTHENTICATED_USERS" />
+        </security-role>
+    </application-bnd>
+</application>
+----
+
+=== Provide a choice of social media providers to the user
+
+You can provide the user with a choice of social media providers on a form from which they choose one to log in with. The following example presents the user with the choice of Google, GitHub, Facebook, LinkedIn, and Twitter with which to log in:
+
+[source,xml]
+----
+<googleLogin clientId="your_app_id" clientSecret="your_app_secret"  />
+<githubLogin   clientid="your_app_id"          clientSecret="your_app_secret"  />
+<facebookLogin clientId="your_app_id"          clientSecret="your_app_secret"  />    
+<linkedinLogin clientId="your_app_id"          clientSecret="your_app_secret"  /> 
+<twitterLogin  consumerKey="your_app_id"       consumerSecret="your_app_secret"/>
+
+<!-- protected apps need to have a security constraint defined -->
+<application type="war" id="formlogin" name="formlogin" location="${server.config.dir}/apps/formlogin.war">
+    <application-bnd>         
+        <security-role name="Employee">
+            <special-subject type="ALL_AUTHENTICATED_USERS" />
+        </security-role>
+    </application-bnd>
+</application>
+----
+
+=== Request log in with a social media ID only if the users is also in another registry
+
+You can restrict the presentation of a social media provider to only users who are also in another configured registry. For example, use the `mapToUserRegistry` attribute to configure your app so that only users in the company LDAP registry can log in with their Google ID:
+
+[source,xml]
+----
+ <googleLogin  mapToUserRegistry="true" clientId="your app id"  clientSecret="your app secret"   />
+
+ <ldapRegistry ...> ... </ldapRegistry>        
+ 
+----
+
+For more information on configuring an LDAP registry, see the LDAP User Registry (feature:ldapRegistry[]) feature.
+
+=== Request log in with a social media ID or with their account for the configured registry
+
+You can give users the option of logging in with either a social media provider or with their account on the configured registry. For example, use the `enableLocalAuthentication` attribute to configure your app so that users can have the option of logging in with a Google ID or with their account on their company's LDAP registry:
+
+[source,xml]
+----
+<!-- user will be presented choice menu of either Google or ldap -->
+<googleLogin  clientId="your app id"  clientSecret="your app secret" />
+
+<socialLoginWebapp enableLocalAuthentication="true">
+
+<ldapRegistry id="ldap" ...> ... </ldapRegistry>     
+ 
+----
+
+=== Request log in with a social media ID for only a subset of applications, URLs, browsers, or IP addresses
+
+To protect only a subset of applications, URLs, or IP addresses, use an authentication filter. 
+The security configuration takes effect only when the conditions in the filter are met. For example,
+you might want a web app to be secured with the Social Media Login feature and a microservice app to be secured with the MicroProfile JWT (feature:mp-jwt[]) feature:
+
+[source,xml]
+----
+<!-- only requests with "/mywebapp" in them will be authenticated using Google. --> 
+<googleLogin  authFilterRef="authFilter1" clientId="your app id"  clientSecret="your app secret" />
+
+<authFilter id="authFilter1">
+    <requestUrl
+        id="myUrlFilter"
+        urlPattern="/mywebapp"
+        matchType="contains" />     
+</authFilter>
+----
+
+For more information, see config:authFilter[]. 
+
+=== Provide other social media logins as options to the user
+
+To authenticate with a social media provider that is not configured out-of-the-box with Open Liberty, use a
+config:oauth2Login[] (for OAuth providers) or config:oidcLogin[] (for OpenID Connect providers) element.
+These elements supply the configuration details needed to work with the provider. These details can usually be
+obtained from the social media provider's developer instructions.  Here is an example for Instagram:
+
+[source,xml]
+----
+<oauth2Login id="instagramLogin" clientId="client_id" clientSecret="client_secret" 
+    scope="basic public_content"   responseType="code" 
+    tokenEndpointAuthMethod="client_secret_post"
+    authorizationEndpoint="https://api.instagram.com/oauth/authorize"
+    tokenEndpoint="https://api.instagram.com/oauth/access_token"
+    userApi="https://api.instagram.com/v1/users/self"
+    userNameAttribute="username"
+    website="https://www.instagram.com/developer/authentication/"> 
+</oauth2Login> 
+----
+
+// LC: Leaving the following links in the source for now to show where this topic should link to when the relevant equivalent topics are published in the Open Liberty docs (do not link to the KC from Open Liberty docs). Remove this commented section when the relevant links are added in future.
+//More information on using the socialLogin feature is available https://www.ibm.com/support/knowledgecenter/en/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/twlp_sec_sociallogin.html[here].
+//More information on using authentication filters is available https://www.ibm.com/support/knowledgecenter/en/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/rwlp_auth_filter.html[here]. 

--- a/ref/general/sync_async_rest_clients.adoc
+++ b/ref/general/sync_async_rest_clients.adoc
@@ -99,9 +99,9 @@ Future<MyResponseObject> future = asyncInvoker.get( new InvocationCallback<MyRes
 ----
 {empty} +
 
-== Synchronous and asynchronous REST with Microprofile
+== Synchronous and asynchronous REST with MicroProfile
 
-Ready to start building microservices with synchronous and asynchronous REST clients? link:/guides/microprofile-rest-client.html[MicroProfile Rest Client] provides a type-safe approach for invoking RESTful services. Although the default implementation is synchronous, you can also make asynchronous calls by using `CompletionStage`. MicroProfile Rest Client provides an easy-to-build template that gets you up and running with RESTful microservices faster, and without having to worry about the boilerplate code. You can also use link:https://github.com/eclipse/microprofile-fault-tolerance[Microprofile's Fault Tolerance feature] to make your asynchronous clients more reliable. MicroProfile Fault Tolerance includes link:https://microprofile.io/project/eclipse/microprofile-fault-tolerance/spec/src/main/asciidoc/asynchronous.asciidoc[the `@Asynchronous` annotation], which enables any method within a class to be invoked by a separate thread.
+Ready to start building microservices with synchronous and asynchronous REST clients? link:/guides/microprofile-rest-client.html[MicroProfile Rest Client] provides a type-safe approach for invoking RESTful services. Although the default implementation is synchronous, you can also make asynchronous calls by using `CompletionStage`. MicroProfile Rest Client provides an easy-to-build template that gets you up and running with RESTful microservices faster, and without having to worry about the boilerplate code. You can also use link:https://github.com/eclipse/microprofile-fault-tolerance[MicroProfile's Fault Tolerance feature] to make your asynchronous clients more reliable. MicroProfile Fault Tolerance includes link:https://microprofile.io/project/eclipse/microprofile-fault-tolerance/spec/src/main/asciidoc/asynchronous.asciidoc[the `@Asynchronous` annotation], which enables any method within a class to be invoked by a separate thread.
 
 
 


### PR DESCRIPTION
- new directory structure to group include files by feature name instead of naming the include files by feature name
- add examples to the Social Media Login feature
- NB. the Audit feature has a commented out entry so that it doesn't build the examples in yet. Easiest way to get the new file structure there without making the new content visible.
