### PR TITLE
remove redundant example

### DIFF
--- a/ref/feature/federatedRegistry/examples.adoc
+++ b/ref/feature/federatedRegistry/examples.adoc
@@ -3,41 +3,7 @@
 
 === Federation of basic registries
 
-If two or more basic registries are configured in your server.xml file or in a userRegistry.xml file, you can combine them into a single federated registry.  To federate two or more basic registries, you must enable both link:/docs/ref/feature/#appSecurity-3.0.html[the Application Security feature] and the Federated User Registry feature, as shown in the following example:
-
-[source,java]
-----
-<server description="Federation">
-    <featureManager>
-        <feature>appSecurity-3.0</feature>
-        <feature>federatedRegistry-1.0</feature>
-    </featureManager>
-
-    <basicRegistry id="basic1" realm="SampleBasicRealm1">
-        <user name="admin" password="password" />
-        <user name="user1" password="password" />
-            <user name="user2" password="password" />
-        <group name="memberlessGroup" />
-        <group name="adminGroup">
-            <member name="admin"/>
-        </group>
-        <group name="users">
-            <member name="user1"/>
-            <member name="user2"/>
-        </group>
-    </basicRegistry>
-
-    <basicRegistry id="basic2" realm="SampleBasicRealm2">
-        <user name="user3" password="password123" />
-        <user name="user4" password="password123" />
-        <group name="memberlessGroup2" />
-        <group name="users2">
-            <member name="user3"/>
-            <member name="user4"/>
-        </group>
-    </basicRegistry>
-</server>
-----
+If two or more basic registries are configured in your server.xml file or in a userRegistry.xml file, you can combine them into a single federated registry.  To federate two or more basic registries, enable both link:/docs/ref/feature/#appSecurity-3.0.html[the Application Security feature] and the Federated User Registry feature and the registries federate by default. In the following example, the two basic registries are federated by default:
 
 User registries that are configured with the `quickStartSecurity` element cannot be federated with other registries.
 For information about basic user registries, see link:/docs/ref/general/#basic-registry.html[Basic user registries for application development].


### PR DESCRIPTION
Since basic registries are federated by default if both AppSecurity and Fed User features are enabled, there's no other config (specific to federation) to show.