### PR TITLE
Remove references to doc-header css

### DIFF
--- a/ref/javadocs/liberty-javaee7-javadoc.html
+++ b/ref/javadocs/liberty-javaee7-javadoc.html
@@ -8,7 +8,6 @@ js:
  - javadocs
 css: 
  - javadocs
- - doc-header
 permalink: /docs/ref/javaee/7/
 ---
 <iframe id="javadoc_container" title="Java Platform Enterprise Edition 7 application programming interface" style="width: 100%;" frameBorder="0" src="/docs/ref/javadocs/liberty-javaee7-javadoc/index.html?overview-summary.html"> 

--- a/ref/javadocs/liberty-javaee8-javadoc.html
+++ b/ref/javadocs/liberty-javaee8-javadoc.html
@@ -8,7 +8,6 @@ js:
  - javadocs
 css: 
  - javadocs
- - doc-header
 permalink: /docs/ref/javaee/8/
 ---
 <iframe id="javadoc_container" title="Java Platform Enterprise Edition 8 application programming interface" style="width: 100%;" frameBorder="0" src="/docs/ref/javadocs/liberty-javaee8-javadoc/index.html?overview-summary.html"> 

--- a/ref/javadocs/microprofile-1.2-javadoc.html
+++ b/ref/javadocs/microprofile-1.2-javadoc.html
@@ -8,7 +8,6 @@ js:
  - javadocs
 css:
  - javadocs
- - doc-header
 permalink: /docs/ref/microprofile/1%2E2/
 ---
 

--- a/ref/javadocs/microprofile-1.3-javadoc.html
+++ b/ref/javadocs/microprofile-1.3-javadoc.html
@@ -8,7 +8,6 @@ js:
  - javadocs
 css:
  - javadocs
- - doc-header
 permalink: /docs/ref/microprofile/1%2E3/
 ---
 

--- a/ref/javadocs/microprofile-1.4-javadoc.html
+++ b/ref/javadocs/microprofile-1.4-javadoc.html
@@ -8,7 +8,6 @@ js:
  - javadocs
 css:
  - javadocs
- - doc-header
 permalink: /docs/ref/microprofile/1%2E4/
 ---
 

--- a/ref/javadocs/microprofile-2.0-javadoc.html
+++ b/ref/javadocs/microprofile-2.0-javadoc.html
@@ -8,7 +8,6 @@ js:
  - javadocs
 css:
  - javadocs
- - doc-header
 permalink: /docs/ref/microprofile/2%2E0/
 ---
 

--- a/ref/javadocs/microprofile-2.1-javadoc.html
+++ b/ref/javadocs/microprofile-2.1-javadoc.html
@@ -8,7 +8,6 @@ js:
  - javadocs
 css:
  - javadocs
- - doc-header
 permalink: /docs/ref/microprofile/2%2E1/
 ---
 

--- a/ref/javadocs/microprofile-2.2-javadoc.html
+++ b/ref/javadocs/microprofile-2.2-javadoc.html
@@ -8,7 +8,6 @@ js:
  - javadocs
 css:
  - javadocs
- - doc-header
 permalink: /docs/ref/microprofile/2%2E2/
 ---
 

--- a/ref/javadocs/microprofile-3.0-javadoc.html
+++ b/ref/javadocs/microprofile-3.0-javadoc.html
@@ -8,7 +8,6 @@ js:
  - javadocs
 css:
  - javadocs
- - doc-header
 permalink: /docs/ref/microprofile/3%2E0/
 ---
 

--- a/ref/javadocs/microprofile-3.2-javadoc.html
+++ b/ref/javadocs/microprofile-3.2-javadoc.html
@@ -8,7 +8,6 @@ js:
  - javadocs
 css:
  - javadocs
- - doc-header
 permalink: /docs/ref/microprofile/3%2E2/
 ---
 

--- a/ref/javadocs/microprofile-3.3-javadoc.html
+++ b/ref/javadocs/microprofile-3.3-javadoc.html
@@ -8,7 +8,6 @@ js:
  - javadocs
 css:
  - javadocs
- - doc-header
 permalink: /docs/ref/microprofile/3%2E3/
 ---
 


### PR DESCRIPTION
This css is no longer used with the consistent navbar on the site.