### PR TITLE
Improve the doc linking macro so that display text can be shown.

### DIFF
--- a/lib/ol-asciidoc.js
+++ b/lib/ol-asciidoc.js
@@ -3,7 +3,7 @@ const { posix: path } = require('path');
 function DocLinkMacros (context, docType) {
   return function () {
     this.process((parent, target, attrs) => {
-      const text = target;
+      const text = attrs['display'] || target;
       const pageId = path.join(path.dirname(context.file.src.relative), target);
       // NOTE the value of the path attribute is never used, so we can fake it
       const attributes = Opal.hash2(['refid', 'path'], { refid: pageId, path: pageId });


### PR DESCRIPTION
The docs macro works right now but it only shows the filename (without extension) on the UI. This will improve it so that we can specify the display text in the macro links in our .adoc files. E.g. `feature:appSecurity[display=Application Security feature]` will show up as `Application Security feature` now such as in the second paragraph:
![image](https://user-images.githubusercontent.com/6392944/91891143-1b71b200-ec56-11ea-9d57-7d58d53d76c9.png)
