### PR TITLE
Update java-se.adoc with current supported level of Java from 14 to 15

### DIFF
--- a/modules/ROOT/pages/java-se.adoc
+++ b/modules/ROOT/pages/java-se.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 IBM Corporation and others.
+// Copyright (c) 2018,2020 IBM Corporation and others.
 // Licensed under Creative Commons Attribution-NoDerivatives
 // 4.0 International (CC BY-ND 4.0)
 //   https://creativecommons.org/licenses/by-nd/4.0/
@@ -10,12 +10,12 @@
 :page-type: general
 = Java SE support
 
-Open Liberty requires a Java SE runtime. A Java SE runtime, also known as a Java Runtime Environment or a Java Developer Kit (JDK), provides the tools to develop, run, and monitor your Java application.
+Open Liberty requires a Java SE runtime. A Java SE runtime, also known as a Java Runtime Environment or a Java Developer Kit (JDK), provides the tools to develop, run, and monitor your Java application. Open Liberty runs on any of the Java versions that are listed in the following sections. 
 
 Always run Open Liberty on the most recent service release of your chosen Java version. A new version of Java is released every six months. Unless the prior version is designated as a Long Term Support (LTS) release, it no longer receives service updates for function and security. Currently, the only LTS releases are Java SE 8 and 11. Whenever a non-LTS release is replaced by the next version, the Open Liberty project no longer validates the runtime against the older version.
 
 == Java SE 8
-Open Liberty runs on any recent Java SE 8 release from IBM, Oracle, or AdoptOpenJDK. The minimum supported level is Java SE 8u25.
+Open Liberty runs on any recent Java SE 8 release from IBM, Oracle, or AdoptOpenJDK. The minimum supported level for Oracle Java is Java SE 8u25.
 
 == Java SE 11
 Open Liberty runs on Java SE 11.0.3 or newer. Keep in mind, if you download your Java SDK from https://adoptopenjdk.net/index.html?variant=openjdk11&jvmVariant=openj9[AdoptOpenJDK], https://www.eclipse.org/openj9/[Eclipse OpenJ9] has a better memory footprint and startup profile than https://openjdk.java.net/groups/hotspot/[HotSpot].
@@ -23,6 +23,6 @@ For more information, see https://openliberty.io/blog/2019/02/06/java-11.html[Op
 
 Due to differences between Java SE 8 and Java SE 11, an Open Liberty application that runs on Java SE 8 might not run on Java SE 11. For more information, see https://docs.oracle.com/en/java/javase/11/migrate/index.html#JSMIG-GUID-C25E2B1D-6C24-4403-8540-CFEA875B994A[Oracle Java SE 11 migration guide].
 
-== Java SE 14
-Open Liberty runs on any recent Java SE 14 release from AdoptOpenJDK, OpenJDK, or Oracle. Java SE 14 is not a long-term supported release. Standard support is scheduled to end in September 2020. Keep in mind, if you download your Java SDK from https://adoptopenjdk.net/index.html?variant=openjdk14&jvmVariant=openj9[AdoptOpenJDK], https://www.eclipse.org/openj9/[Eclipse OpenJ9] has a better memory footprint and startup profile than https://openjdk.java.net/groups/hotspot/[HotSpot].
+== Java SE 15
+Open Liberty runs on any recent Java SE 15 release from AdoptOpenJDK, OpenJDK, or Oracle. Java SE 15 is not a long-term supported release. Standard support is scheduled to end in March 2021. Keep in mind, if you download your Java SDK from https://adoptopenjdk.net/index.html?variant=openjdk15&jvmVariant=openj9[AdoptOpenJDK], https://www.eclipse.org/openj9/[Eclipse OpenJ9] has a better memory footprint and startup profile than https://openjdk.java.net/groups/hotspot/[HotSpot].
 For more information, see https://openliberty.io/blog/2019/02/06/java-11.html[Open Liberty and Java 11].


### PR DESCRIPTION
With Java 15 being released (and the simultaneous discontinuation of support for Java 14), the list of supported versions of Java by Open Liberty needs to be updated. The only file needing to be changed is modules/ROOT/pages/java-se.adoc.

This update is to go out with the 20.0.0.12 release.

This pull request is tied to issue #2590 

Link to draft build with my changes working -> https://draft-openlibertyio.mybluemix.net/docs/20.0.0.12/java-se.html

