### PR TITLE
Missing period in config overview

### DIFF
--- a/modules/reference/pages/config/server-configuration-overview.adoc
+++ b/modules/reference/pages/config/server-configuration-overview.adoc
@@ -244,9 +244,9 @@ The default is `${wlp.user.dir}/servers/${wlp.server.name}`.
 The default is `${server.config.dir}`.
 
 == Configuration merging
-Since the configuration can consist of multiple files, it is possible that two files provide the same  configuration
+Since the configuration can consist of multiple files, it is possible that two files provide the same configuration.
 In these situations, the server configuration is merged according to a set of simple rules.
-In {projectName}, configuration is separated into singleton and factory  configuration each of which has its own rules for merging.
+In {projectName}, configuration is separated into singleton and factory configuration each of which has its own rules for merging.
 Singleton configuration is used to configure a single element (for example, logging).
 Factory configuration is used to configure multiple entities, such as an entire application or data source.
 


### PR DESCRIPTION
Looks good on [draft site](https://docs-draft-openlibertyio.mybluemix.net/docs/21.0.0.1/reference/config/server-configuration-overview.html):
![image](https://user-images.githubusercontent.com/3076261/102112173-f36d1f80-3dfc-11eb-89c6-2bad76275fef.png)
