### PR TITLE
Update relational-database-connections-JDBC.adoc

### DIFF
--- a/modules/ROOT/pages/relational-database-connections-JDBC.adoc
+++ b/modules/ROOT/pages/relational-database-connections-JDBC.adoc
@@ -43,12 +43,14 @@ If you use Maven to build your application, you can download and deploy the JDBC
 <plugin>
 <groupId>io.openliberty.tools</groupId>
 <artifactId>liberty-maven-plugin</artifactId>
-<version>3.3-M2</version>
+<version>3.3</version>
   <configuration>
     <copyDependencies>
+      <location>jdbc</location>
       <dependency>
-        <filter>com.ibm.db2:jcc:11.5.4.0</filter>
-        <location>jdbc</location>
+        <groupId>com.ibm.db2</groupId>
+        <artifactId>jcc</artifactId>
+        <version>11.5.4.0</version>
       </dependency>
     </copyDependencies>
   </configuration>


### PR DESCRIPTION
update for 3.3 final plugin.

`<filter>` seems to be no longer recognized

refs:
- https://github.com/OpenLiberty/blogs/issues/857#issuecomment-729057247
- https://github.com/OpenLiberty/ci.maven/issues/705#issuecomment-733922480