### PR TITLE
Update java-se.adoc for Java 16 support in Open Liberty

### DIFF
--- a/modules/ROOT/pages/java-se.adoc
+++ b/modules/ROOT/pages/java-se.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018,2020 IBM Corporation and others.
+// Copyright (c) 2018,2021 IBM Corporation and others.
 // Licensed under Creative Commons Attribution-NoDerivatives
 // 4.0 International (CC BY-ND 4.0)
 //   https://creativecommons.org/licenses/by-nd/4.0/
@@ -23,6 +23,6 @@ For more information, see https://openliberty.io/blog/2019/02/06/java-11.html[Op
 
 Due to differences between Java SE 8 and Java SE 11, an Open Liberty application that runs on Java SE 8 might not run on Java SE 11. For more information, see https://docs.oracle.com/en/java/javase/11/migrate/index.html#JSMIG-GUID-C25E2B1D-6C24-4403-8540-CFEA875B994A[Oracle Java SE 11 migration guide].
 
-== Java SE 15
-Open Liberty runs on any recent Java SE 15 release from AdoptOpenJDK, OpenJDK, or Oracle. Java SE 15 is not a long-term supported release. Standard support is scheduled to end in March 2021. Keep in mind, if you download your Java SDK from https://adoptopenjdk.net/index.html?variant=openjdk15&jvmVariant=openj9[AdoptOpenJDK], https://www.eclipse.org/openj9/[Eclipse OpenJ9] has a better memory footprint and startup profile than https://openjdk.java.net/groups/hotspot/[HotSpot].
+== Java SE 16
+Open Liberty runs on any recent Java SE 16 release from AdoptOpenJDK, OpenJDK, or Oracle. Java SE 16 is not a long-term supported release and standard support is scheduled to end in September 2021. Keep in mind, if you download your Java SDK from https://adoptopenjdk.net/index.html?variant=openjdk16&jvmVariant=openj9[AdoptOpenJDK], https://www.eclipse.org/openj9/[Eclipse OpenJ9] has a better memory footprint and startup profile than https://openjdk.java.net/groups/hotspot/[HotSpot].
 For more information, see https://openliberty.io/blog/2019/02/06/java-11.html[Open Liberty and Java 11].


### PR DESCRIPTION
With Java 16 being released (and the simultaneous discontinuation of support for Java 15), the list of supported versions of Java by Open Liberty needs to be updated. The only file needing to be changed is modules/ROOT/pages/java-se.adoc.

This update is to go out in a TDB release.

This pull request is tied to issue #3765 

We need to hold off pushing this out to production until Java 16 support is official in Open Liberty.