### PR TITLE
clarify separation of batch vs admin roles

### DIFF
--- a/modules/ROOT/pages/admin-center.adoc
+++ b/modules/ROOT/pages/admin-center.adoc
@@ -136,24 +136,25 @@ Each batch job has an **Actions** icon, which you can select to stop, restart, o
 
 If batch jobs or job logs are on remote servers, link:/guides/cors.html[configure cross origin region sharing (CORS)] on each remote server. CORS enables Admin Center to request job information from remote servers.
 
-Note too that the batch features use a custom authorization specific to batch and role membership must be granted separately from the roles needed to access the Admin Center in the first place.  
-
-E.g. a 'batchadmin' user configured like:
+The Batch Management feature requires custom authorization to view and manage batch jobs. To use the Java Batch tool, you must configure a `com.ibm.ws.batch` custom authorization role, in addition to the reader or administrator role that is required to access the Admin Center. The following server.xml example shows configuration for a user, `wanda`, who is granted the administrator management role and the batchAdmin custom authorization role:
 
 [source,xml]
 ----
-  <reader-role>
-      <user>batchadmin</user>
-  </reader-role>
+  <administrator-role>
+      <user>wanda</user>
+  </administrator-role>
 
   <authorization-roles id="com.ibm.ws.batch">
       <security-role name="batchAdmin">
-          <user name="batchadmin"/>
+          <user name="wanda"/>
       </security-role>
   </authorization-roles>
 ----
 
-could use the Java Batch tool to view and operate on any and all jobs (as 'batchAdmin') but a user with just 'administrator-role' access might require one of the 'com.ibm.ws.batch' custom roles in order to even view any jobs at all (they are not automatically a 'batch-admin').
+With this configuration, the user has authorization to view and manage any configured Java batch jobs.  The `batchAdmin` authority could be combined with a more fine-grained, restrictive management authority by only granting 'wanda' the `reader-role` management role, which would still allow access to the Admin Center Java Batch tool.
+
+On the other hand, if no custom batch authorization role is configured, even a user in the administrator management role cannot view or manage Java batch jobs. For more information, see https://www.ibm.com/docs/en/was-liberty/nd?topic=liberty-securing-batch-environment[Securing the Liberty batch environment].
+
 
 [#openid]
 === Administer Open ID Connect Provider tasks with the OpenID Connect (OIDC) tools

--- a/modules/ROOT/pages/admin-center.adoc
+++ b/modules/ROOT/pages/admin-center.adoc
@@ -151,9 +151,11 @@ The Batch Management feature requires custom authorization to view and manage ba
   </authorization-roles>
 ----
 
-With this configuration, the user has authorization to view and manage any configured Java batch jobs.  The `batchAdmin` authority could be combined with a more fine-grained, restrictive management authority by only granting 'wanda' the `reader-role` management role, which would still allow access to the Admin Center Java Batch tool.
+With this configuration, the user has authorization to view and manage any configured Java batch jobs.
 
-On the other hand, if no custom batch authorization role is configured, even a user in the administrator management role cannot view or manage Java batch jobs. For more information, see https://www.ibm.com/docs/en/was-liberty/nd?topic=liberty-securing-batch-environment[Securing the Liberty batch environment].
+The `batchAdmin` role can also be combined with a more restrictive Liberty management role by assigning 'wanda' to `reader-role`. This combination still allows full access to the Java Batch tool but provides read-only access to other Admin Center resources.
+
+However, if no custom batch authorization role is configured, even a user in the administrator management role cannot view or manage Java batch jobs. For more information, see https://www.ibm.com/docs/en/was-liberty/nd?topic=liberty-securing-batch-environment[Securing the Liberty batch environment].
 
 
 [#openid]

--- a/modules/ROOT/pages/admin-center.adoc
+++ b/modules/ROOT/pages/admin-center.adoc
@@ -67,7 +67,7 @@ image::ui_login.png[The Admin Center login screen,align="center"]
 
 == Select tools from the Toolbox
 
-After you log in toÂ Admin Center, the browser displays the **Toolbox**, which contains tools such as the **Server Config** and **Explore** tools and a bookmark to link:https://openliberty.io[openliberty.io]. The following screen capture shows the Admin Center **Toolbox**:
+After you log in to Admin Center, the browser displays the **Toolbox**, which contains tools such as the **Server Config** and **Explore** tools and a bookmark to link:https://openliberty.io[openliberty.io]. The following screen capture shows the Admin Center **Toolbox**:
 
 image::ui_toolbox.png[align="center"]
 
@@ -128,13 +128,32 @@ You can add more resource metrics to the **Monitor** view by selecting the **Edi
 [#batch]
 === Manage Java batch jobs with the Java Batch tool
 
-If you configureÂ the feature:batchManagement[display=Batch Management] feature, you can access the **Java Batch** tool. With this tool, you can view the progress and status of your Java batch jobs, manage their instances, and view their log files. The following screen capture shows the **Java Batch** tool:
+If you configure the feature:batchManagement[display=Batch Management] feature, you can access the **Java Batch** tool. With this tool, you can view the progress and status of your Java batch jobs, manage their instances, and view their log files. The following screen capture shows the **Java Batch** tool:
 
 image::ui_javaBatchTool.png[align="center"]
 
 Each batch job has an **Actions** icon, which you can select to stop, restart, or purge the job, and a **View Logs** icon, which you can select to view the job logs. To view details and metrics for a batch job, hover over the **Batch Job Name** and select an option from the tooltip menu.
 
 If batch jobs or job logs are on remote servers, link:/guides/cors.html[configure cross origin region sharing (CORS)] on each remote server. CORS enables Admin Center to request job information from remote servers.
+
+Note too that the batch features use a custom authorization specific to batch and role membership must be granted separately from the roles needed to access the Admin Center in the first place.  
+
+E.g. a 'batchadmin' user configured like:
+
+[source,xml]
+----
+  <reader-role>
+      <user>batchadmin</user>
+  </reader-role>
+
+  <authorization-roles id="com.ibm.ws.batch">
+      <security-role name="batchAdmin">
+          <user name="batchadmin"/>
+      </security-role>
+  </authorization-roles>
+----
+
+could use the Java Batch tool to view and operate on any and all jobs (as 'batchAdmin') but a user with just 'administrator-role' access might require one of the 'com.ibm.ws.batch' custom roles in order to even view any jobs at all (they are not automatically a 'batch-admin').
 
 [#openid]
 === Administer Open ID Connect Provider tasks with the OpenID Connect (OIDC) tools


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

Sorry I didn't catch this new article before the initial effort and am only commenting now.

@dmuelle is it OK to link to the WL  KCtr (whatever it's called now) from the OL doc?  

If so, I might reference:   https://www.ibm.com/docs/en/was-liberty/nd?topic=liberty-securing-batch-environment

Note the first two changes here removed a non-display char that I assume was added by mistake.