### PR TITLE
4536-Update-HTTP-AccessLog-Documentation

### DIFF
--- a/modules/ROOT/pages/access-logging.adoc
+++ b/modules/ROOT/pages/access-logging.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2013, 2019 IBM Corporation and others.
+// Copyright (c) 2013, 2021 IBM Corporation and others.
 // Licensed under Creative Commons Attribution-NoDerivatives
 // 4.0 International (CC BY-ND 4.0)
 //   https://creativecommons.org/licenses/by-nd/4.0/
@@ -10,7 +10,7 @@
 :page-type: general
 = HTTP access logging
 
-You can configure access log settings for HTTP endpoints. An HTTP access log contains a record of all inbound client requests that are handled by HTTP endpoints. You can enable access logging in the HTTP server or the Liberty server in two modes:
+You can configure access log settings for HTTP endpoints. An HTTP access log contains a record of all inbound client requests that are handled by HTTP endpoints. You can enable access logging in the HTTP Server or the Liberty Server in two modes:
 
 * A single log for multiple endpoints
 * One log for each endpoint
@@ -79,10 +79,10 @@ The following table lists the available log format options.
 `0` is printed instead of `-` if no value is found.
 
 |%{CookieName}C or %C
-|The request cookie specified within the brackets. If the brackets are not included, prints all of the request cookies.
+|The request cookie that is specified within the brackets. If the brackets are not included, print all of the request cookies.
 
 |%D
-|The elapsed time of the request - millisecond accuracy, microsecond precision
+|The elapsed time of the request in microseconds.
 
 |%h
 |Remote host
@@ -133,7 +133,7 @@ The order that you specify the options determines the format of this information
  %h %i %u %t "%r" %s %b %D %{R}W
 ----
 
-Based on this setting, the NCSA access log will include the following information for each request in the specified order:
+Based on this setting, the NCSA access log includes the following information for each request in the specified order:
 
 * The remote host
 * The HeaderName header value from the request


### PR DESCRIPTION
Liberty's documentation is no longer accurate: Liberty's implementation now uses nanosecond accuracy.

Corrected. #4536