### PR TITLE
Update java-se.adoc for Java 17 support in Open Liberty

### DIFF
--- a/modules/ROOT/pages/java-se.adoc
+++ b/modules/ROOT/pages/java-se.adoc
@@ -12,7 +12,7 @@
 
 Open Liberty requires a Java SE runtime. It can run by using either a JRE (Java Runtime Environment) or a JDK (Java SE Development Kit) distribution. Open Liberty runs on any of the Java SE versions that are listed in the following sections.
 
-Always run Open Liberty on the most recent service release of your chosen Java version. A new version of Java SE is released every six months. Unless the prior version is designated as a Long Term Support (LTS) release, it no longer receives service updates for function and security. Currently, the only LTS releases are Java SE 8 and 11. Whenever a non-LTS release is replaced by the next version, the Open Liberty project no longer validates the runtime against the older version.
+Always run Open Liberty on the most recent service release of your chosen Java version. A new version of Java SE is released every six months. Unless the prior version is designated as a Long Term Support (LTS) release, it no longer receives service updates for function and security. Currently, the only LTS releases are Java SE 8, 11 and 17. Whenever a non-LTS release is replaced by the next version, the Open Liberty project no longer validates the runtime against the older version.
 
 == Java SE 8
 Open Liberty runs on any recent Java SE 8 release from https://developer.ibm.com/languages/java/semeru-runtimes/downloads/[IBM Semeru], https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html[Oracle], or https://adoptium.net/?variant=openjdk8&jvmVariant=hotspot[Eclipse Adoptium] (formerly AdoptOpenJDK). The minimum supported level for Oracle Java is Java SE 8u25.
@@ -23,5 +23,13 @@ For more information, see https://openliberty.io/blog/2019/02/06/java-11.html[Op
 
 Due to differences between Java SE 8 and Java SE 11, an Open Liberty application that runs on Java SE 8 might not run on Java SE 11. For more information, see https://docs.oracle.com/en/java/javase/11/migrate/index.html#JSMIG-GUID-C25E2B1D-6C24-4403-8540-CFEA875B994A[Oracle Java SE 11 migration guide].
 
-== Java SE 15
-Open Liberty runs on any recent Java SE 15 release. Java SE 15 is not a long-term supported release and standard support is scheduled to end in March 2021. Keep in mind, if you download your Java SDK from https://adoptopenjdk.net/index.html?variant=openjdk16&jvmVariant=openj9[AdoptOpenJDK], https://www.eclipse.org/openj9/[Eclipse OpenJ9] has a better memory footprint and startup profile than https://openjdk.java.net/groups/hotspot/[HotSpot]. For more information, see Open Liberty and Java 11.
+== Java SE 17
+Open Liberty runs on Java SE 17.0.0 or newer.  Java SE 17 is a long-term supported release and can be downloaded as a Semeru build from http://ibm.biz/GetSemeru[IBM] or a Temurin build from https://adoptium.net/[adoptium.net].  Semeru has a better memory footprint and startup profile than Temurin.  Please note, Semeru and Temurin Java 17 builds might not be generally available at the time of this posting.
+
+For more information, see (<link to blog of OL supporting Java 17 release information>)[Open Liberty and Java 17].  
+
+Due to differences between Java SE 8 or 11 and 17, an Open Liberty application that runs on Java SE 8 or 11 might not run on Java SE 17.  
+For more information on Java SE 17, see https://blogs.oracle.com/javamagazine/migrate-to-java-17[Oracle Java SE 17 migration blog] or https://docs.oracle.com/en/java/javase/17/migrate/toc.htm[Oracle Java SE 17 migration guide].
+
+== Migration tools
+To get started scanning for Java SE differences, try the https://www.ibm.com/support/pages/websphere-migration-knowledge-collection-downloads[WebSphere migration tools].


### PR DESCRIPTION
With Java 17 being released soon (and the simultaneous discontinuation of support for Java 15), the list of supported versions of Java by Open Liberty needs to be updated. The only file needing to be changed is modules/ROOT/pages/java-se.adoc.

This update is to go out in a TDB release.

This pull request is tied to docs issue #4545 

We need to hold off pushing this out to production until Java 17 support for Hotspot is official in Open Liberty.

Previous version update for reference #3766 