### PR TITLE
Remove copy to clipboard for some code snippets

### DIFF
--- a/modules/ROOT/pages/forwarding-logs-logstash.adoc
+++ b/modules/ROOT/pages/forwarding-logs-logstash.adoc
@@ -70,7 +70,7 @@ d:\wlp\bin\securityUtility createSSLCertificate --server=server1 --password="Lib
 ----
 The `key.p12` default keystore file is created under the `wlp_install_dir/usr/servers/server1/resources/security` directory. The output from this command is similar to the following example:
 +
-[role,command]
+[role="no_copy",command]
 ----
 Creating keystore wlp_install_dir/usr/servers/server1/resources/security/key.p12
 

--- a/modules/ROOT/pages/slow-hung-request-detection.adoc
+++ b/modules/ROOT/pages/slow-hung-request-detection.adoc
@@ -55,6 +55,7 @@ The following log message sample shows the log messages for a request that cross
 The default duration value is 10 min.
 The value that is configured in the following example is 4 min.
 
+[role="no_copy"]
 ----
 [WARNING ] TRAS0114W: Request AAA7WlpP7l7_AAAAAAAAAAA was running on thread 00000021 for at least 240001.015ms. The following table shows the events that have run during this request.
 Duration       Operation


### PR DESCRIPTION
- These code snippets are not meant for users to copy and paste into
their terminal or code.