### PR TITLE
Remove copy to clipboard for some code snippets

### DIFF
--- a/modules/ROOT/pages/forwarding-logs-logstash.adoc
+++ b/modules/ROOT/pages/forwarding-logs-logstash.adoc
@@ -70,7 +70,7 @@ d:\wlp\bin\securityUtility createSSLCertificate --server=server1 --password="Lib
 ----
 The `key.p12` default keystore file is created under the `wlp_install_dir/usr/servers/server1/resources/security` directory. The output from this command is similar to the following example:
 +
-[role,command]
+[role="no_copy",command]
 ----
 Creating keystore wlp_install_dir/usr/servers/server1/resources/security/key.p12
 

--- a/modules/ROOT/pages/log-trace-configuration.adoc
+++ b/modules/ROOT/pages/log-trace-configuration.adoc
@@ -63,11 +63,13 @@ Each of the three Open Liberty primary log files has a default log format and se
 The following examples show sample output in each of the available log formats and list the logs for which each format is available: `DEV`, `SIMPLE`, `JSON`, `TBASIC`, `ENHANCED`, and `ADVANCED`.
 
 DEV (console log)::
+[source,console]
 ----
 [AUDIT   ] CWWKF0011I: The defaultServer server is ready to run a smarter planet. The defaultServer server started in 7.967 seconds.
 ----
 
 SIMPLE (console and messages logs)::
+[source,console]
 ----
 [18/10/21 14:49:26:246 EDT] 0000003e com.ibm.ws.kernel.feature.internal.FeatureManager            A CWWKF0011I: The defaultServer server is ready to run a smarter planet. The defaultServer server started in 7.844 seconds
 ----
@@ -79,11 +81,13 @@ JSON (console and messages logs)::
 ----
 
 TBASIC (console, messages, and trace logs)::
+[source,console]
 ----
 [18/10/21 14:47:19:718 EDT] 0000003e FeatureManage A   CWWKF0011I: The defaultServer server is ready to run a smarter planet. The defaultServer server started in 7.718 seconds.
 ----
 
 ENHANCED (trace log)::
+[source,console]
 ----
 [26/10/21 10:42:42:300 EDT] 0000006d id=00000000 x.com.ibm.ws.collector.manager.buffer.BufferManagerImpl      3 Adding event to buffer GenericData
 [type=com.ibm.ws.logging.source.trace,ibm_datetime=1635259362300,ibm_messageId=null,ibm_threadId=109,module=com.ibm.ws.event.internal.EventImpl,severity=
@@ -92,6 +96,7 @@ ENHANCED (trace log)::
 ----
 
 ADVANCED (trace log)::
+[source,console]
 ----
 [26/10/21 10:29:25:011 EDT] 00000073  > UOW= source=com.ibm.ws.event.internal.EventImpl method=setProperty id=5f05cd40 org= prod= component=
           Entry

--- a/modules/ROOT/pages/log-trace-configuration.adoc
+++ b/modules/ROOT/pages/log-trace-configuration.adoc
@@ -60,7 +60,7 @@ Each of the three Open Liberty primary log files has a default log format and se
 - The default format for the `messages.log` file is `SIMPLE`.
 - The default format for the `trace.log` file is `ENHANCED`.
 
-The following examples show sample output in each of the available log formats: `DEV`, `SIMPLE`, `JSON`, `TBASIC`, `ENHANCED`, and `ADVANCED`.
+The following examples show sample output in each of the available log formats and list the logs for which each format is available: `DEV`, `SIMPLE`, `JSON`, `TBASIC`, `ENHANCED`, and `ADVANCED`.
 
 DEV (console log)::
 ----

--- a/modules/ROOT/pages/log-trace-configuration.adoc
+++ b/modules/ROOT/pages/log-trace-configuration.adoc
@@ -54,28 +54,28 @@ com.ibm.ws.logging.copy.system.streams=false
 [#log_formats]
 == Log formats
 
-Each of the three Open Liberty primary log files has a default log format and several alternative formats that you can specify in your logging configuration. The format that you choose for each log depends on the needs of your application and your infrastructure. For example, you might choose to output your messages log in JSON format if it is consumed by a log analysis platform. Alternatively, you might choose the TBASIC format for all three logs if you need a consistent log format across all of your log files.
+Each of the three Open Liberty primary log files has a default log format and several alternative formats that you can specify in your logging configuration. The format that you choose for each log depends on the needs of your application and your infrastructure. For example, you might choose to output your messages log in JSON format if it is consumed by a log analysis platform. Alternatively, you might choose the `TBASIC` format for all three logs if you need a consistent log format across all of your log files.
 
 - The default format for the `console.log` file is `DEV`.
 - The default format for the `messages.log` file is `SIMPLE`.
 - The default format for the `trace.log` file is `ENHANCED`.
 
-The following examples show sample output in each of the available log formats: `DEV`, `SIMPLE`, `JSON`, `TBASIC` `ENHANCED`, and `ADVANCED`.
+The following examples show sample output in each of the available log formats: `DEV`, `SIMPLE`, `JSON`, `TBASIC`, `ENHANCED`, and `ADVANCED`.
 
 DEV (console log)::
 ----
-[AUDIT   ] CWWKF0011I: The defaultServer server is ready to run a smarter planet. The defaultServer server started in 7.967 seconds.`
+[AUDIT   ] CWWKF0011I: The defaultServer server is ready to run a smarter planet. The defaultServer server started in 7.967 seconds.
 ----
 
 SIMPLE (console and messages logs)::
 ----
-[18/10/21 14:49:26:246 EDT] 0000003e com.ibm.ws.kernel.feature.internal.FeatureManager            A CWWKF0011I: The defaultServer server is ready to run a smarter planet. The defaultServer server started in 7.844 seconds`
+[18/10/21 14:49:26:246 EDT] 0000003e com.ibm.ws.kernel.feature.internal.FeatureManager            A CWWKF0011I: The defaultServer server is ready to run a smarter planet. The defaultServer server started in 7.844 seconds
 ----
 
 JSON (console and messages logs)::
 [source,json]
 ----
-{"type":"liberty_message","host":"HOST","ibm_userDir":"/wlp\/usr\/","ibm_serverName":"defaultServer","message":"CWWKF0011I: The defaultServer server is ready to run a smarter planet. The defaultServer server started in 7.967 seconds.","ibm_threadId":"0000003e","ibm_datetime":"2021-10-18T14:50:58.159-0400","ibm_messageId":"CWWKF0011I","module":"com.ibm.ws.kernel.feature.internal.FeatureManager","loglevel":"AUDIT","ibm_sequence":"1634583058159_0000000000009"}`
+{"type":"liberty_message","host":"HOST","ibm_userDir":"/wlp\/usr\/","ibm_serverName":"defaultServer","message":"CWWKF0011I: The defaultServer server is ready to run a smarter planet. The defaultServer server started in 7.967 seconds.","ibm_threadId":"0000003e","ibm_datetime":"2021-10-18T14:50:58.159-0400","ibm_messageId":"CWWKF0011I","module":"com.ibm.ws.kernel.feature.internal.FeatureManager","loglevel":"AUDIT","ibm_sequence":"1634583058159_0000000000009"}
 ----
 
 TBASIC (console, messages, and trace logs)::
@@ -108,7 +108,7 @@ However, the output differs between the trace log and that of the console and me
 The TBASIC format provides a consistent format option for the trace, console, and messages logs that matches the `BASIC` option for the trace log.
 The `TBASIC` format acts as an alias for the `BASIC` option.
 
-You can specify the `TBASIC` format  in the `bootstrap.properties` file, as shownn in the following example:
+You can specify the `TBASIC` format  in the `bootstrap.properties` file, as shown in the following example:
 
 ----
 com.ibm.ws.logging.message.format=tbasic

--- a/modules/ROOT/pages/slow-hung-request-detection.adoc
+++ b/modules/ROOT/pages/slow-hung-request-detection.adoc
@@ -26,6 +26,7 @@ The default threshold value is 10 seconds.
 
 The following example shows the format of a log message:
 
+[role="no_copy"]
 ----
 TRAS0112W: Request <(Request ID)> has been running on thread <THREADID> for at least <DURATION>. The following stack trace shows that this thread is currently running.
 <STACK TRACE>

--- a/modules/ROOT/pages/slow-hung-request-detection.adoc
+++ b/modules/ROOT/pages/slow-hung-request-detection.adoc
@@ -55,6 +55,7 @@ The following log message sample shows the log messages for a request that cross
 The default duration value is 10 min.
 The value that is configured in the following example is 4 min.
 
+[role="no_copy"]
 ----
 [WARNING ] TRAS0114W: Request AAA7WlpP7l7_AAAAAAAAAAA was running on thread 00000021 for at least 240001.015ms. The following table shows the events that have run during this request.
 Duration       Operation


### PR DESCRIPTION
Related to https://github.com/OpenLiberty/openliberty.io/issues/2263
Tested on [staging website](https://draft-openlibertyio.mybluemix.net/docs/21.0.0.12/forwarding-logs-logstash.html) using PR https://github.com/OpenLiberty/docs/pull/4926 and https://github.com/OpenLiberty/openliberty.io/pull/2354

The docs pages how have the ability to remove the `copy to clipboard` button on code snippets that are not meant to be copied by visitors.  An example of code snippet that does not need `copy to clipboard` is output from a command.

- These code snippets are not meant for users to copy and paste into
their terminal or code.