### PR TITLE
Update security-vulnerabilities adoc for 22.0.0.2

### DIFF
--- a/modules/ROOT/pages/security-vulnerabilities.adoc
+++ b/modules/ROOT/pages/security-vulnerabilities.adoc
@@ -18,6 +18,13 @@ The following table lists the CVEs that affect Open Liberty, ordered by the rele
 |===
 |CVE |CVSS Score |Vulnerability Assessment |Versions Affected |Version Fixed |Notes
 
+|http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-39031[CVE-2021-39031]
+|7.5
+|LDAP injection
+|17.0.0.3 - 22.0.0.1
+|22.0.0.2
+|Affects the feature:ldapRegistry-3.0[] feature
+
 |http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-22310[CVE-2022-22310]
 |4.8
 |Information disclosure


### PR DESCRIPTION
This update is for adding new CVE to security vulnerability list based on issue and PR delivered into 22.0.0.2 under the following:
https://github.com/OpenLiberty/open-liberty/issues/19915
https://github.com/OpenLiberty/open-liberty/pull/19916