### PR TITLE
Access log documentation cleanup

### DIFF
--- a/modules/ROOT/pages/access-logging.adoc
+++ b/modules/ROOT/pages/access-logging.adoc
@@ -121,8 +121,6 @@ If no value is found, `0` is printed instead of `-`.
 |%U
 |The URL Path, not including the query string
 
-|%{X}W
-|The Cross Component Tracing (XCT) Context ID
 
 |===
 

--- a/modules/reference/pages/feature/openapi-3.1/description.adoc
+++ b/modules/reference/pages/feature/openapi-3.1/description.adoc
@@ -1,0 +1,1 @@
+The `openapi-3.1` feature is stabilized. The strategic alternative is the feature:mpOpenAPI[display=MicroProfile OpenAPI] feature.


### PR DESCRIPTION
Cross Component Tracing (XCT) is not supported in Liberty. As such, the %{X}W directive is invalid. The access log documentation should be cleaned up to remove mentions of XCT.