### PR TITLE
Update server-configuration-hardening.adoc

### DIFF
--- a/modules/ROOT/pages/server-configuration-hardening.adoc
+++ b/modules/ROOT/pages/server-configuration-hardening.adoc
@@ -163,6 +163,9 @@ You can also disable automatic configuration updates in the `server.xml` file by
 ----
 <config updateTrigger="mbean" />
 ----
+[#Client data at rest]
+== Client data at rest
+Use password encryption to secure client data at rest, i.e., passwords.
 
 [#password-encryption]
 == Password encryption


### PR DESCRIPTION
Per CISO, must address client data at rest, which in Liberty's case consists of passwords.

Proposing the doc be updated to include the following:

[#Client data at rest]
== Client data at rest
Use password encryption to secure client data at rest, i.e., passwords.
