### PR TITLE
suggested updates to jdbc logging docs

### DIFF
--- a/modules/ROOT/pages/jdbc-tracing.adoc
+++ b/modules/ROOT/pages/jdbc-tracing.adoc
@@ -15,232 +15,251 @@
 :page-layout: general-reference
 :page-type: general
 
-= JDBC Tracing for Open Liberty
+= JDBC Driver Tracing for Open Liberty
 
-JDBC tracing for Open Liberty enables tracing for your third-party JDBC driver for debugging purposes, or to submit a ticket.
-JDBC tracing is enabled either through a driver-specific custom trace setting, or by using the application server supplemental JDBC tracing option.
+JDBC tracing for Open Liberty enables tracing for your third-party JDBC driver for debugging purposes, or to submit a support ticket.
+In order to collect JDBC trace you will need to enable tracing for your JDBC driver in Liberty, configure the logging level, and optionally provide driver specific configurations when applicible.
 
-If your JDBC driver does not provide its own custom tracing, logging facilities, or the facilities it provides are minimal, you can use supplemental JDBC tracing from the application server.
+== Understanding Open Liberty Tracing
 
-You can use one of the following two options for driver-specific custom trace facilities.
+Open Liberty has a unified logging component that is backed by the native Java logging library, java.util.logging (JUL).
+Open Liberty users have the ability to customize the trace produced by their applications, third-party libraries, and the server runtime.
+The JUL library uses the package structure of Java libraries and applications to allow users to specify the scope of logging they want to produce.
+You can configure trace using either `bootstrap.properties` or `server.xml`, examples of both configurations are provided in this documentation.
 
-* Use the Java™ built-in logging mechanism, `java.util.logging`, if the driver supports it.
-* Configure a custom trace setting as a vendor property.
+> For a more detailed article on Open Liberty tracing please read the [Log and trace configuration](https://openliberty.io/docs/latest/log-trace-configuration.html) documentation.
 
+== Understanding your JDBC Driver
 
-If you enable tracing by using either a custom vendor property or supplemental JDBC tracing, you must add the logwriter name to the trace specification in the `bootstrap.properties` file.
-You can use any of the following logwriters.
+Your thrid-party JDBC driver will either use the native Java logging library, or some other logging library such as SLF4J or Log4J. 
+If your JDBC driver uses the JUL library, then you can enable logging for your JDBC driver by providing a trace specification corresponding to the package name used by the driver.
+If your JDBC driver uses some other logging library, then Open Liberty will provide a logwriter that will generate logs based off of the JDBC specification methods (getConnection, executeQuery, etc.). 
 
-.Logwriters available for JDBC tracing
+The following table lists the most common JDBC drivers, if they support JUL, and the recommended trace specification (package name or logwriter).
+
+.Third-Party JDBC Drivers
 |===
-| Logwriter | Attribute
+| JDBC Driver | Uses JUL | Trace Specification
 
-|**DB2®**
-|com.ibm.ws.db2.logwriter
+|**DB2 JCC**
+|True
+|com.ibm.db2
 
 |**Derby**
+|False - Print writer
 |com.ibm.ws.derby.logwriter
 
-|**Informix® JDBC**
-|com.ibm.ws.informix.logwriter
+|**Informix using JDBC**
+|True
+|com.informix
 
-|**Informix® JCC**
-|com.ibm.ws.informix.jcclogwriter
+|**Informix using DB2 JCC**
+|True
+|com.ibm.db2
 
-|**Microsoft SQL Server JDBC and DataDirect**
+|**Microsoft SQL Server JDBC**
+|True
+|com.microsoft.sqlserver.jdbc
+
+|**Microsoft SQL Server DataDirect**
+|False
 |com.ibm.ws.sqlserver.logwriter
 
 |**Oracle**
-|com.ibm.ws.oracle.logwriter
+|True
+|oracle
 
 |**PostreSQL**
+|False - SLF4J
 |com.ibm.ws.postgresql.logwriter
 
 |**Sybase**
+|False
 |com.ibm.ws.sybase.logwriter
 
 |**Other databases (for example MySQL)**
+|False - Unknown
 |com.ibm.ws.database.logwriter
-
-|**All databases**
-|WAS.database
 |===
 
-Changes are made to the trace enablement by altering the `bootstrap.properties` file. However, you must restart the server for the changes to take effect.
+== Recommended Trace Configuration for Support
 
-== JDBC trace methods
+The following examples contain the trace configuration when enabling trace for JDBC support.
 
-* <<#java_util_logging, Use java.util.logging>>
-* <<#custom_trace, Use custom trace settings>>
-* <<#supplemental_jdbc_trace, Use supplemental JDBC tracing>>
-** <<#enable_supplemental_trace, Enable supplemental tracing>>
-** <<#disable_supplemental_trace, Disable supplemental tracing>>
-
-
-[#java_util_logging]
-=== Use java.util.logging
-
-You can enable JDBC tracing by appending the driver trace level to `com.ibm.ws.logging.trace.specification` in the `bootstrap.properties` file.
-
-The following example shows you how to append the driver trace level for the Microsoft SQL Server JDBC Driver.
-
-[source,sh]
+.bootstrap.properties
+[source, properties]
 ----
-com.ibm.ws.logging.trace.specification=*=audit:com.microsoft.sqlserver.jdbc=FINE
+com.ibm.ws.logging.trace.specification=*=info:RRA=all
+com.ibm.ws.logging.max.files=10
+com.ibm.ws.logging.max.file.size=100
 ----
 
-The following example shows you how to append the driver trace level for the Oracle JDBC or Oracle Universal Connection Pool (UCP).
-
-[source,sh]
+.server.xml
+[source, xml]
 ----
-com.ibm.ws.logging.trace.specification=*=audit:oracle=FINE
-----
-
-For Oracle, you must also enable tracing by setting the `oracle.jdbc.Trace` system property to true. You can use one of the following two options.
-
-* In the `bootstrap.properties` file, add the `oracle.jdbc.Trace=true` setting.
-* In a Java program, add the `System.setProperty("oracle.jdbc.Trace","true")` setting.
-
-
-[#custom_trace]
-=== Use custom trace settings
-
-If the driver you are using has custom trace settings, you set them as JDBC driver vendor properties in the `server.xml` file.
-You also add the logwriter name to the trace specification in the `bootstrap.properties` file.
-
-The following examples shows you how to use custom trace settings, using the `traceLevel` custom property.
-
-In the `server.xml` file.
-[source,sh]
-----
-<dataSource id="db2" jndiName="jdbc/db2" jdbcDriverRef="DB2Driver" >
-    <properties.db2.jcc databaseName="myDB" traceLevel="-1"/>
-</dataSource>
+<logging traceSpecification="*=info:RRA=all" maxFiles=10 maxFileSize=100 />
 ----
 
-In the `bootstrap.properties` file:
-[source,sh]
-----
-com.ibm.ws.logging.trace.specification=*=audit:com.ibm.ws.db2.logwriter=all
-----
+== Enabling trace for your JDBC driver
 
+The following sub-sections contain JDBC driver specfic configuration.
 
-The following examples show you how to use custom trace settings for Derby Network Client.
+=== DB2 JCC
 
-In the `server.xml` file.
-[source,sh]
+.bootstrap.properties
+[source, properties]
 ----
-<dataSource id="derbyNC" jndiName="jdbc/derbyNC" jdbcDriverRef="DerbyNC" >
-    <properties.derby.client databaseName="myDB" createDatabase="create" traceLevel="1"/>
-</dataSource>
+com.ibm.ws.logging.trace.specification=*=info:RRA=all:com.ibm.db2=all
 ----
 
-In the `bootstrap.properties` file:
-[source,sh]
+.server.xml
+[source, xml]
 ----
-com.ibm.ws.logging.trace.specification=*=audit:com.ibm.ws.derby.logwriter=all
-----
+<logging traceSpecification="*=info:RRA=all:com.ibm.db2=all" ... />
 
-
-The following examples show you how to use custom trace settings for Informix JCC. This database uses the DB2 drivers for JCC connectivity.
-
-In the `server.xml` file.
-[source,sh]
-----
-<dataSource id="informixJCC" jndiName="jdbc/informixJCC" jdbcDriverRef="InformixDriverJCC" >
-    <properties.informix.jcc databaseName="myDB" traceLevel="-1"/>
-</dataSource>
+<datasource ...>
+  <!-- traceLevel -1 is equivalent to ALL -->
+  <propertes.db2.jcc traceLevel="-1"/>
+</datasource>
 ----
 
-In the `bootstrap.properties` file:
-[source,sh]
+=== Derby
+
+.bootstrap.properties
+[source, properties]
 ----
-com.ibm.ws.logging.trace.specification=*=audit:com.ibm.ws.db2.logwriter=all
-----
-
-[#supplemental_jdbc_trace]
-=== Use supplemental JDBC tracing
-
-You can use supplemental JDBC tracing from the application server, if your JDBC driver does not provide suitable tracing or logging facilities.
-The application server automatically determines whether to enable supplemental JDBC tracing, based on the JDBC driver used.
-
-To override automatic determination on enabling supplemental JDBC tracing, set the `supplementalJDBCTrace` data source property to true or false.
-
-
-[#enable_supplemental_trace]
-==== Enable supplemental tracing
-
-Supplemental JDBC tracing for an embedded Derby database is enabled by default. You need to set the logwriter in the `bootstrap.properties` file.
-
-The following examples show you how to enable supplemental tracing by specifying the logwriter in the `bootstrap.properties` file.
-[source,sh]
-----
-com.ibm.ws.logging.trace.specification=*=audit:com.ibm.ws.derby.logwriter=all
+com.ibm.ws.logging.trace.specification=*=info:RRA=all:com.ibm.ws.derby.logwriter=all
 ----
 
-
-The following example shows you how to enable supplemental tracing with Informix JDBC. Supplemental JDBC tracing is enabled by default for this database.
-[source,sh]
+.server.xml
+[source, xml]
 ----
-com.ibm.ws.logging.trace.specification=*=audit:com.ibm.ws.informix.logwriter=all
-----
-
-
-The following example shows you how to enable supplemental tracing and `java.util.logging`, with Microsoft SQL Server JDBC Driver.
-[source,sh]
-----
-com.ibm.ws.logging.trace.specification=*=audit:com.ibm.ws.sqlserver.logwriter=all:
-com.microsoft.sqlserver.jdbc=all
+<logging traceSpecification="*=info:RRA=all:com.ibm.ws.derby.logwriter=all" />
 ----
 
+=== Informix using JDBC
 
-The following example shows you how to enable supplemental tracing with DataDirect Connect for JDBC for Microsoft SQL Server.
-[source,sh]
+.bootstrap.properties
+[source, properties]
 ----
-com.ibm.ws.logging.trace.specification=*=audit:com.microsoft.sqlserver.jdbc=all
-----
-
-
-The following example shows you how to enable supplemental tracing with solidDB. Supplemental JDBC tracing is enabled by default for this database.
-[source,sh]
-----
-com.ibm.ws.logging.trace.specification=*=audit:com.ibm.ws.database.logwriter=all
+com.ibm.ws.logging.trace.specification=*=info:RRA=all:com.informix=all
 ----
 
-
-The following example shows you how to enable supplemental tracing with Sybase. Supplemental JDBC tracing is enabled by default for this database.
-[source,sh]
+.server.xml
+[source, xml]
 ----
-com.ibm.ws.logging.trace.specification=*=audit:com.ibm.ws.sybase.logwriter=all
-----
-
-
-The following example shows you how to enable supplemental tracing with other databases.
-[source,sh]
-----
-com.ibm.ws.logging.trace.specification=*=audit:com.ibm.ws.database.logwriter=all
+<logging traceSpecification="*=info:RRA=all:com.informix=all" />
 ----
 
+=== Informix using DB2 JCC
 
-[#disable_supplemental_trace]
-==== Disable supplemental tracing
-
-You can disable supplemental JDBC tracing by setting the `supplementalJDBCTrace` data source property to false in the `server.xml` file,
-or by removing the logwriter name from the `com.ibm.ws.logging.trace.specification` property in the `bootstrap.properties` file.
-
-The following example shows the changes that are made to the `supplementalJDBCTrace` data source property in the `server.xml` file to disable supplemental JDBC tracing.
-
-[source,sh]
+.bootstrap.properties
+[source, properties]
 ----
-<dataSource id="soliddb" jndiName="jdbc/soliddb"
- jdbcDriverRef="solidDBDriver" supplementalJDBCTrace="false">
- <properties databaseName="dba" URL="jdbc:solid://localhost:2315/dba/dba" />
-</dataSource>
+com.ibm.ws.logging.trace.specification=*=info:RRA=all:com.ibm.db2=all
 ----
 
-The following example shows the changes that are made to the `com.ibm.ws.logging.trace.specification` property in the `bootstrap.properties` file to disable supplemental JDBC tracing.
-
-[source,sh]
+.server.xml
+[source, xml]
 ----
-com.ibm.ws.logging.trace.specification=*=audit
+<logging traceSpecification="*=info:RRA=all:com.ibm.db2=all" />
+
+<datasource ... >
+  <!-- traceLevel -1 is equivalent to ALL -->
+  <properties.informix.jcc traceLevel="-1"/>
+</datasource>
+----
+
+=== Microsoft SQL Server JDBC driver
+
+.bootstrap.properties
+[source, properties]
+----
+com.ibm.ws.logging.trace.specification=*=info:RRA=all:com.microsoft.sqlserver.jdbc=all
+----
+
+.server.xml
+[source, xml]
+----
+<logging traceSpecification="*=info:RRA=all:com.microsoft.sqlserver.jdbc=all" />
+----
+
+=== Microsoft SQL Server DataDirect driver
+
+.bootstrap.properties
+[source, properties]
+----
+com.ibm.ws.logging.trace.specification=*=info:RRA=all:com.ibm.ws.sqlserver.logwriter=all
+----
+
+.server.xml
+[source, xml]
+----
+<logging traceSpecification="*=info:RRA=all:com.ibm.ws.sqlserver.logwriter=all" />
+----
+
+=== Oracle
+
+.bootstrap.properties
+[source, properties]
+----
+com.ibm.ws.logging.trace.specification=*=info:RRA=all:oracle=all
+----
+
+.server.xml
+[source, xml]
+----
+<logging traceSpecification="*=info:RRA=all:oracle=all" />
+
+<library id="oracleDebug">
+    <file name="${path.to.oracle.dir}/ojdbcX_g.jar"/>
+</library>
+----
+
+.jvm.options
+[source, txt]
+----
+-Doracle.jdbc.Trace=true
+----
+
+=== PostreSQL
+
+.bootstrap.properties
+[source, properties]
+----
+com.ibm.ws.logging.trace.specification=*=info:RRA=all:com.ibm.ws.postgresql.logwriter=all
+----
+
+.server.xml
+[source, xml]
+----
+<logging traceSpecification="*=info:RRA=all:com.ibm.ws.postgresql.logwriter=all" />
+----
+
+=== Sybase
+
+.bootstrap.properties
+[source, properties]
+----
+com.ibm.ws.logging.trace.specification=*=info:RRA=all:com.ibm.ws.sybase.logwriter=all
+----
+
+.server.xml
+[source, xml]
+----
+<logging traceSpecification="*=info:RRA=all:com.ibm.ws.sybase.logwriter=all" />
+----
+
+=== Other databases
+
+.bootstrap.properties
+[source, properties]
+----
+com.ibm.ws.logging.trace.specification=*=info:RRA=all:com.ibm.ws.database.logwriter=all
+----
+
+.server.xml
+[source, xml]
+----
+<logging traceSpecification="*=info:RRA=all:com.ibm.ws.database.logwriter=all" />
 ----


### PR DESCRIPTION
@ramkumar-k-9286 I meet with our L2 to go over this document and I put together a rough draft of some of the information we'd like to be updated/included.
Major points: 
1. Better distinction between using a logwriter (supplemental tracing) and java.util.logging. 
2. Having a recommended trace file size, and file count. 
3. Individual configuration sections for each database (so support can link to that specific database)

As it is now there is a lot of repetition of information.  I'm not sure how best to remedy that without complicating the documentation.  Which I suppose is what happened with the Knowledge Center page. 