### PR TITLE
5301-Migrate-JDBC-add-link

### DIFF
--- a/modules/ROOT/pages/relational-database-connections-JDBC.adoc
+++ b/modules/ROOT/pages/relational-database-connections-JDBC.adoc
@@ -36,6 +36,8 @@ To connect with a relational database, you need a JDBC driver, which is typicall
 
 Open Liberty recognizes the implementation class names of various data source types for commonly used JDBC drivers. In most cases, you need to specify only the location of the JDBC driver.
 
+For more information about configuring trace for your JDBC driver, see xref:ROOT:pages/jdbc-tracing.adoc[JDBC tracing].
+
 === JDBC driver configuration with Maven or Gradle
 
 If you use https://maven.apache.org[Maven] or https://gradle.org[Gradle] build tools to build your application, you can configure a dependency to copy the JDBC driver files to the `${server.config.dir}/jdbc` directory. The driver files must be copied after the server is created but before the application is deployed so that the database instance is available to the  application at run time.


### PR DESCRIPTION
Adding a link to JDBC tracing doc from Relational Database Connections JDBC doc.

Migrate-JDBC-add-link

#5301