### PR TITLE
Suggested updates for the JDBC driver trace doc

### DIFF
--- a/modules/ROOT/pages/jdbc-tracing.adoc
+++ b/modules/ROOT/pages/jdbc-tracing.adoc
@@ -91,7 +91,7 @@ The following subsections contain JDBC driver specific configuration.
 - <<#SQLServerJDBCdriver,Microsoft SQL Server JDBC driver>>
 - <<#SQLServerDataDirectdriver,Microsoft SQL Server DataDirect driver>>
 - <<#Oracle,Oracle>>
-- <<#PostreSQL,PostreSQL>>
+- <<#PostgreSQL,PostgreSQL>>
 - <<#Sybase,Sybase>>
 - <<#Otherdatabases,Other databases>>
 
@@ -116,7 +116,7 @@ For more information about valid values for the `traceLevel` attribute, see http
 [#Derby]
 === Derby
 
-The Derby driver does not support the `java.util.logging` library. The driver uses the `com.ibm.ws.derby.logwriter` log writer name in the trace specification. The following `server.xml` file example shows you the configuration to enable trace for the Derby driver.
+The Derby driver does not support the `java.util.logging` library. Open Liberty provides the `com.ibm.ws.derby.logwriter` log writer name in the trace specification. The following `server.xml` file example shows you the configuration to enable trace for the Derby driver.
 
 [source, xml]
 ----
@@ -167,7 +167,7 @@ The Microsoft SQL Server JDBC driver supports the `java.util.logging` library. T
 [#SQLServerDataDirectdriver]
 === Microsoft SQL Server DataDirect driver
 
-The Microsoft SQL Server DataDirect driver does not support the `java.util.logging` library. The driver uses the `com.ibm.ws.sqlserver.logwriter` log writer name in the trace specification. The following `server.xml` file example shows you the configuration to enable trace for the Microsoft SQL Server DataDirect driver.
+The Microsoft SQL Server DataDirect driver does not support the `java.util.logging` library. Open Liberty provides the `com.ibm.ws.sqlserver.logwriter` log writer name in the trace specification. The following `server.xml` file example shows you the configuration to enable trace for the Microsoft SQL Server DataDirect driver.
 
 [source, xml]
 ----
@@ -180,7 +180,7 @@ The Microsoft SQL Server DataDirect driver does not support the `java.util.loggi
 
 Oracle provides two different drivers, one for production and another for debugging purposes. The production driver does not produce any trace, so you need to download and replace your production driver with the debugging driver. The debugging driver has `_g` in the driver name. For example, `ojdbc8.jar` is `ojdbc8_g.jar`. Configure the debugging driver by specifying the `library` subelement within the `jdbcDriver` element. The `library` subelement defines the path to the debugging driver JAR file.
 
-The Oracle driver supports the `java.util.logging` library. The driver uses the `Oracle` package name in the trace specification. The following `server.xml` file example shows you how to configure the Oracle debugging driver and enable trace.
+The Oracle driver supports the `java.util.logging` library. The driver uses the `oracle` package name in the trace specification. The following `server.xml` file example shows you how to configure the Oracle debugging driver and enable trace.
 
 [source, xml]
 ----
@@ -199,10 +199,17 @@ The trace that is produced by the debugging driver is limited. You can add the f
 ----
 
 
-[#PostreSQL]
-=== PostreSQL
+[#PostgreSQL]
+=== PostgreSQL
 
-The PostreSQL driver does not support the `java.util.logging` library. The driver uses the `com.ibm.ws.postgresql.logwriter` log writer name in the trace specification. The following `server.xml` file example shows you the configuration to enable trace for the PostreSQL driver.
+The PostgreSQL driver since version 42.0.0 supports the `java.util.logging` library. The driver uses the `org.postgresql` package name in the trace specification. The following `server.xml` file example shows you the configuration to enable trace for the PostgreSQL driver.
+
+[source, xml]
+----
+<logging traceSpecification="*=info:RRA=all:org.postgresql=all" />
+----
+
+The PostgreSQL driver before version 42.0.0 does not support the `java.util.logging` library. Open Liberty provides the `com.ibm.ws.postgresql.logwriter` log writer name in the trace specification. The following `server.xml` file example shows you the configuration to enable trace for the PostgreSQL driver.
 
 [source, xml]
 ----
@@ -213,7 +220,7 @@ The PostreSQL driver does not support the `java.util.logging` library. The drive
 [#Sybase]
 === Sybase
 
-The Sybase driver does not support the `java.util.logging` library. The driver uses the `com.ibm.ws.sybase.logwriter` log writer name in the trace specification. The following `server.xml` file example shows you the configuration to enable trace for the Sybase driver.
+The Sybase driver does not support the `java.util.logging` library. Open Liberty provides the `com.ibm.ws.sybase.logwriter` log writer name in the trace specification. The following `server.xml` file example shows you the configuration to enable trace for the Sybase driver.
 
 [source, xml]
 ----

--- a/modules/ROOT/pages/jdbc-tracing.adoc
+++ b/modules/ROOT/pages/jdbc-tracing.adoc
@@ -209,7 +209,7 @@ The PostgreSQL driver since version 42.0.0 supports the `java.util.logging` libr
 <logging traceSpecification="*=info:RRA=all:org.postgresql=all" />
 ----
 
-The PostgreSQL driver before version 42.0.0 does not support the `java.util.logging` library. Open Liberty provides the `com.ibm.ws.postgresql.logwriter` log writer name in the trace specification. The following `server.xml` file example shows you the configuration to enable trace for the PostgreSQL driver.
+The PostgreSQL driver prior to version 42.0.0 does not support the `java.util.logging` library. Open Liberty provides the `com.ibm.ws.postgresql.logwriter` log writer name in the trace specification. The following `server.xml` file example shows you the configuration to enable trace for the PostgreSQL driver.
 
 [source, xml]
 ----

--- a/modules/ROOT/pages/jdbc-tracing.adoc
+++ b/modules/ROOT/pages/jdbc-tracing.adoc
@@ -202,7 +202,7 @@ The trace that is produced by the debugging driver is limited. You can add the f
 [#PostgreSQL]
 === PostgreSQL
 
-The PostgreSQL driver since version 42.0.0 supports the `java.util.logging` library. The driver uses the `org.postgresql` package name in the trace specification. The following `server.xml` file example shows you the configuration to enable trace for the PostgreSQL driver.
+The PostgreSQL driver version 42.0.0 and later supports the `java.util.logging` library. The driver uses the `org.postgresql` package name in the trace specification. The following `server.xml` file example shows the configuration to enable trace for the PostgreSQL driver.
 
 [source, xml]
 ----

--- a/modules/ROOT/pages/jdbc-tracing.adoc
+++ b/modules/ROOT/pages/jdbc-tracing.adoc
@@ -209,7 +209,7 @@ The PostgreSQL driver version 42.0.0 and later supports the `java.util.logging` 
 <logging traceSpecification="*=info:RRA=all:org.postgresql=all" />
 ----
 
-The PostgreSQL driver prior to version 42.0.0 does not support the `java.util.logging` library. Open Liberty provides the `com.ibm.ws.postgresql.logwriter` log writer name in the trace specification. The following `server.xml` file example shows you the configuration to enable trace for the PostgreSQL driver.
+Prior to version 42.0.0, the PostgreSQL driver  does not support the `java.util.logging` library. Open Liberty provides the `com.ibm.ws.postgresql.logwriter` log writer name in the trace specification. The following `server.xml` file example shows the configuration to enable trace for the PostgreSQL driver in versions earlier than 42.0.0.
 
 [source, xml]
 ----


### PR DESCRIPTION
Wanted to clarify some wording to make sure it is clear that the Driver is not supplying the com.ibm.x.logwriter trace and that it is an open liberty feature that does that. 

Additionally, the PostgreSQL Driver does use java.util.logging.  The doc I had previously read from Postgre about logging was out of date. The PostgreSQL driver has used JUL since version 42.0.0.

Finally, there were some spots where PostgreSQL was missing the g.