### PR TITLE
Remove docker container instuctions and replace with links to Docker Hub

### DIFF
--- a/modules/ROOT/pages/relational-database-connections-JDBC.adoc
+++ b/modules/ROOT/pages/relational-database-connections-JDBC.adoc
@@ -194,30 +194,8 @@ The following example shows a sample data source configuration for a PostgreSQL 
 </dataSource>
 ----
 
-To run a Postgres Docker container locally, run the following command:
+https://hub.docker.com/_/postgres[The Postgres Docker container is available on Docker Hub.]
 
-[source,command]
-----
-docker run -it --rm=true --memory-swappiness=0 --ulimit memlock=-1:-1 \
-           --name postgres-liberty \
-           -e POSTGRES_USER=exampleUser \
-           -e POSTGRES_PASSWORD=examplePassword \
-           -e POSTGRES_DB=myDB \
-           -p 5432:5432 \
-           postgres:10.5
-----
-
-If you use https://docs.podman.io/en/latest[Podman] to manage your containers, run the following command
-
-----
-podman run -it --rm=true --memory-swappiness=0 --ulimit memlock=-1:-1 \
-           --name postgres-liberty \
-           -e POSTGRES_USER=exampleUser \
-           -e POSTGRES_PASSWORD=examplePassword \
-           -e POSTGRES_DB=myDB \
-           -p 5432:5432 \
-           postgres:10.5
-----
 [#Db2]
 === IBM Db2
 
@@ -235,34 +213,7 @@ The following example shows a sample data source configuration for an IBM Db2 da
 </dataSource>
 ----
 
-To run an IBM Db2 Docker container locally, run the following command:
-
-[source,command]
-----
-docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 \
-           --name db2-liberty \
-           -e AUTOCONFIG=false -e ARCHIVE_LOGS=false -e LICENSE=accept \
-           -e DBNAME=test \
-           -e Db2INSTANCE=db2inst1 \
-           -e Db2INST1_PASSWORD=foobar1234 \
-           -p 50000:50000 \
-           --privileged \
-           ibmcom/db2:11.5.0.0a
-----
-
-If you use https://docs.podman.io/en/latest[Podman] to manage your containers, run the following command:
-[source,command]
-----
-podman run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 \
-           --name db2-liberty \
-           -e AUTOCONFIG=false -e ARCHIVE_LOGS=false -e LICENSE=accept \
-           -e DBNAME=test \
-           -e Db2INSTANCE=db2inst1 \
-           -e Db2INST1_PASSWORD=foobar1234 \
-           -p 50000:50000 \
-           --privileged \
-           ibmcom/db2:11.5.0.0a
-----
+https://hub.docker.com/r/ibmcom/db2[The Db2 Docker container is available on Docker Hub.]
 
 [#Microsoft]
 === Microsoft SQL Server
@@ -282,29 +233,7 @@ The following example shows a sample data source configuration for a Microsoft S
 </dataSource>
 ----
 
-To run a Microsoft SQL Server Docker container locally, run the following command:
-
-[source,command]
-----
-docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 \
-           --name mssql-liberty \
-           -e ACCEPT_EULA=Y \
-           -e SA_PASSWORD=examplePassw0rd \
-           -p 1433:1433 \
-           mcr.microsoft.com/mssql/server:2019-GA-ubuntu-16.04
-----
-
-If you use https://docs.podman.io/en/latest[Podman] to manage your containers, run the following command:
-
-[source,command]
-----
-podman run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 \
-           --name mssql-liberty \
-           -e ACCEPT_EULA=Y \
-           -e SA_PASSWORD=examplePassw0rd \
-           -p 1433:1433 \
-           mcr.microsoft.com/mssql/server:2019-GA-ubuntu-16.04
-----
+https://hub.docker.com/_/microsoft-mssql-server[The Microsoft SQL Server Docker container is available on Docker Hub.]
 
 [#MySQL]
 === MySQL
@@ -322,30 +251,7 @@ The following example shows a sample data source configuration for a MySQL datab
                 password="examplePassword"/>
 </dataSource>
 ----
-
-To run a MySQL Docker container locally, run the following command:
-[source,command]
-----
-docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 \
-           --name mysql-liberty \
-           -e MYSQL_DATABASE=myDB \
-           -e MYSQL_USER=exampleUser \
-           -e MYSQL_PASSWORD=examplePassword \
-           -p 3306:3306 \
-           mysql:8
-----
-
-If you use https://docs.podman.io/en/latest[Podman] to manage your containers, run the following command:
-[source,command]
-----
-podman run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 \
-           --name mysql-liberty \
-           -e MYSQL_DATABASE=myDB \
-           -e MYSQL_USER=exampleUser \
-           -e MYSQL_PASSWORD=examplePassword \
-           -p 3306:3306 \
-           mysql:8
-----
+https://hub.docker.com/_/mysql[The MySQL Docker container is available on Docker Hub.]
 
 [#Embedded]
 === Embedded Derby
@@ -375,6 +281,8 @@ The following example shows a sample data source configuration for an Oracle dat
                 user="exampleUser"
                 password="examplePassword"/>
 </dataSource>
+
+https://hub.docker.com/r/gvenzl/oracle-xe[The Oracle Docker container is available on Docker Hub.]
 ----
 
 [#Oracleucp]


### PR DESCRIPTION
The docker and podman instructions triple the space required for each database, and will frequently become out of date as new versions are released. By linking to the docker images instead we can save space and users can get the latest images and instructions directly from the image maintainers.