### PR TITLE
Correct dependencies

### DIFF
--- a/modules/ROOT/pages/micrometer-metrics.adoc
+++ b/modules/ROOT/pages/micrometer-metrics.adoc
@@ -73,6 +73,9 @@ In this example, a directory for the Micrometer libraries and dependencies at `/
 ----
 // Micrometer core
     - micrometer-core-1.9.3.jar
+// Micrometer core dependencies
+    - HdrHistogram-2.1.12.jar
+    - LatencyUtils-2.0.3.jar
 // Micrometer Prometheus registry
     - micrometer-registry-prometheus-1.9.3.jar
 // Micrometer Prometheus registry's dependencies
@@ -84,12 +87,8 @@ In this example, a directory for the Micrometer libraries and dependencies at `/
 // Micrometer Influx registry
     - micrometer-registry-influx-1.9.3.jar
 // Micrometer Influx registry dependencies
-    - hamcrest-core-1.3.jar
-    - junit-4.11.jar
     - slf4j-api-1.7.36.jar
-// Shared dependencies between Influx and Prometheus Micrometer registries
-    - HdrHistogram-2.1.12.jar
-    - LatencyUtils-2.0.3.jar
+
 ----
 
 The following example shows the corresponding `server.xml` file configuration to specify the enabling Micrometer properties and provide the shared library.


### PR DESCRIPTION
Mistake of assigning micrometer core's dependencies to Prometheus only.
Also left a junit dependency in the pom.xml when generating the dependencies, therefore the junit and hamcrest dependencies are not associated to the meter registries.