### PR TITLE
Update java-se.adoc for Java 20 support in Open Liberty

### DIFF
--- a/modules/ROOT/pages/java-se.adoc
+++ b/modules/ROOT/pages/java-se.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018,2021 IBM Corporation and others.
+// Copyright (c) 2018,2023 IBM Corporation and others.
 // Licensed under Creative Commons Attribution-NoDerivatives
 // 4.0 International (CC BY-ND 4.0)
 //   https://creativecommons.org/licenses/by-nd/4.0/
@@ -62,12 +62,12 @@ The following table lists the Java SE versions that Open Liberty supports and pr
 |https://adoptium.net/?variant=openjdk17&jvmVariant=hotspot[Eclipse Adoptium 17]
 |https://docs.oracle.com/en/java/javase/17/migrate/toc.htm[Java SE 17 migration guide]
 
-|19
+|20
 |No
 |
 |
-|https://adoptium.net/temurin/releases/?version=19[Eclipse Adoptium 19]
-|https://docs.oracle.com/en/java/javase/19/migrate/toc.htm[Java SE 19 migration guide]
+|https://adoptium.net/temurin/releases/?version=20[Eclipse Adoptium 20]
+|https://docs.oracle.com/en/java/javase/20/migrate/toc.htm[Java SE 20 migration guide]
 |===
 
 == Migration tools


### PR DESCRIPTION
With Java 20 being released soon (and the simultaneous discontinuation of support for Java 19), the list of supported versions of Java by Open Liberty needs to be updated. The only file needing to be changed is modules/ROOT/pages/java-se.adoc.

This update is to go out in a TDB release.

This pull request is tied to docs issue https://github.com/OpenLiberty/docs/issues/6381

We need to hold off pushing this out to production until Java 20 support for Hotspot is official in Open Liberty.

Java 19 version update for reference https://github.com/OpenLiberty/docs/pull/5695