### PR TITLE
Remove link and add logging levels

### DIFF
--- a/modules/ROOT/pages/jdbc-tracing.adoc
+++ b/modules/ROOT/pages/jdbc-tracing.adoc
@@ -232,7 +232,7 @@ You can also customize the configured trace in the `jvm.options` file by using o
 -DoracleLogFileSizeLimit=<size-in-bytes>
 -DoracleLogFileCount=<number-of-files>
 -DoracleLogFormat=<SimpleFormatter|XMLFormatter|your-fully-qualified-class>
--DoracleLogTraceLevel=<SEVERE|WARNING|INFO|CONFIG|FINE|FINER|FINEST>
+-DoracleLogTraceLevel=<OFF|SEVERE|WARNING|INFO|CONFIG|FINE|FINER|FINEST|ALL>
 ----
 
 The previous properties are optional. If no values are configured, Liberty uses the following default values:
@@ -242,7 +242,7 @@ The previous properties are optional. If no values are configured, Liberty uses 
 - `oracleLogFormat`: SimpleFormatter (the simple formatter from java.util.logging)
 - `oracleLogTraceLevel`: INFO
 
-For Oracle recommended settings, see their https://docs.oracle.com/en/database/oracle/oracle-database/21/jjdbc/JDBC-diagnosability.html#GUID-5E8CB599-C7D8-48E7-87E7-53559D22D318[support page].
+For Oracle recommended settings, see their support page.
 
 [#PostgreSQL]
 === PostgreSQL

--- a/modules/ROOT/pages/jdbc-tracing.adoc
+++ b/modules/ROOT/pages/jdbc-tracing.adoc
@@ -242,7 +242,7 @@ The previous properties are optional. If no values are configured, Liberty uses 
 - `oracleLogFormat`: SimpleFormatter (the simple formatter from java.util.logging)
 - `oracleLogTraceLevel`: INFO
 
-For Oracle recommended settings, see their support page.
+For Oracle recommended settings, see the Oracle documentation.
 
 [#PostgreSQL]
 === PostgreSQL


### PR DESCRIPTION
Based on feedback from my team. 
* Oracle links could break unexpectedly so best not to use them.
* Add in the absolute logging levels.  