### PR TITLE
Update enable-fips.adoc

### DIFF
--- a/modules/ROOT/pages/enable-fips.adoc
+++ b/modules/ROOT/pages/enable-fips.adoc
@@ -19,7 +19,7 @@ For more information about enabling FIPS for Liberty with the IBM SDK, Java Tech
 == Enable FIPS for Open Liberty on IBM Semeru Runtimes
 
 You can enable either IBM Semeru Runtime Certified Edition or Open Edition in FIPS mode in version 11.0.16 and later for Java 11 and version 17.0.4 and later for Java 17. Java 11 and 17 support for FIPS with Semeru Runtimes is available only on Red Hat Enterprise Linux (RHEL) 8 on x86 platforms. The RHEL 8 operating system must be running in FIPS mode because the IBM Semeru Runtimes rely on the operating system’s underlying Network Security Services (NSS) FIPS 140-2 certification. To run Open Liberty on IBM Semeru Runtimes in FIPS mode, Open Liberty version 22.0.0.8 or later is recommended.
-In FIPS mode, Semeru Runtimes does not support file-based keystores like JKS and PKCS#12. Certificates in your file-based keystores must be imported into the NSS database.
+In FIPS mode, Semeru Runtimes does not support file-based keystores like JKS and PKCS#12. Certificates in your file-based keystores must be imported into the NSS database. Open Liberty does not create certificates in the NSS database.
 
 Complete the following steps to configure your Open Liberty server to run on Semeru Runtimes in FIPS mode and to add your keys and certificates to the NSS database.
 


### PR DESCRIPTION
For #6497 Sentence added reads: Open Liberty does not create certificates in the NSS database.