### PR TITLE
6897-correction to session_liveSessions metric description

### DIFF
--- a/modules/ROOT/pages/metrics-list.adoc
+++ b/modules/ROOT/pages/metrics-list.adoc
@@ -732,7 +732,7 @@ This metric is a counter.
 
 |session.liveSessions{appname=<appName>}
 |session_liveSessions{appname="<appName>",mp_scope="vendor"}
-|The number of users that are currently logged in since this metric was enabled.
+|The number of users that are currently logged in.
 This metric is a gauge.
 |`Session`
 |{vendor-metric-features}


### PR DESCRIPTION
correction to session_liveSessions metric description

#6897