### PR TITLE
6897-correction to session_liveSessions metric description-2

### DIFF
--- a/modules/ROOT/pages/metrics-list.adoc
+++ b/modules/ROOT/pages/metrics-list.adoc
@@ -1421,7 +1421,7 @@ This metric is a counter.
 
 |session.liveSessions{appname=<appName>}
 |vendor_session_liveSessions{appname="<appName>"}
-|The number of users that are currently logged in since this metric was enabled.
+|The number of users that are currently logged in.
 This metric is a gauge.
 |`Session`
 |{vendor-metric-features}


### PR DESCRIPTION
correction to session_liveSessions metric description-2

#6897