### PR TITLE
Fix configDropins path

### DIFF
--- a/modules/ROOT/pages/server-configuration-hardening.adoc
+++ b/modules/ROOT/pages/server-configuration-hardening.adoc
@@ -147,8 +147,8 @@ By default, each server contains a monitored application directory that's named 
 When an application is placed in this directory, the server automatically deploys and starts the application.
 If you update the configuration in the `server.xml` file or the `/dropins` directory, the server automatically deploys the configuration changes.
 
-Each server also contains a monitored directory that's named `/dropins/configDropins` for configuration snippets.
-If you update the configuration in this directory, the server automatically deploys the configuration changes.
+Each server also contains a directory named `/configDropins` with monitored subdirectories `/configDropins/defaults` and `/configDropins/overrides` for configuration snippets.
+If you update the configuration in either of these two subdirectories, the server automatically deploys the configuration changes.
 
 To ensure that you deploy only explicitly pre-configured applications where their configuration is in the `server.xml` file, disable monitoring of the `/dropins` directory:
 


### PR DESCRIPTION
This should be just `<server.config.dir>/configDropins` not `<server.config.dir>/dropins/configDropins`.  

Added reworded to reflect the two subdirs.

@dmuelle 