### PR TITLE
Mention <executor> element in thread pool tuning

### DIFF
--- a/modules/ROOT/pages/thread-pool-tuning.adoc
+++ b/modules/ROOT/pages/thread-pool-tuning.adoc
@@ -17,7 +17,7 @@
 = Thread pool tuning
 
 Open Liberty provides a self-tuning algorithm that controls the size of its thread pool.
-Although you do not need to manually tune the thread pool for most applications, in some cases you might need to adjust the `coreThreads` and `maxThreads` attributes.
+Although you do not need to manually tune the thread pool for most applications, in some cases you might need to explicitly configure an `executor` element and adjust the `coreThreads` and `maxThreads` attributes to particular values.
 
 All the application code in Open Liberty runs in a single thread pool that is called the default executor.
 The size of this pool is set by a self-tuning controller, which can manage a wide range of workloads.


### PR DESCRIPTION
It seems just a bit incomplete to mention the need to set the two specific attributes, but without any mention of the element of which these are attributes.

Something like this I think is all that's needed, (however worded).

True, there's a "See also" link to the executor elem config at the bottom, but maybe it should appear in this article.

Or, we could go to the lengths of adding a sample element w/ attrs.