### PR TITLE
Update JDBC trace for Oracle 23c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_STORE
+.vscode/*
+.vscode/**/*
 antora-playbook.yml

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "asciidoc.antora.enableAntoraSupport": true
-}

--- a/modules/ROOT/pages/jdbc-tracing.adoc
+++ b/modules/ROOT/pages/jdbc-tracing.adoc
@@ -179,7 +179,7 @@ The Microsoft SQL Server DataDirect driver does not support the `java.util.loggi
 [#Oracle]
 === Oracle
 
-Prior to Oracle 23c Oracle provided two different drivers, one for production and another for debugging purposes. The production driver does not produce any trace, so you need to download and replace your production driver with the debugging driver. The debugging driver has `_g` in the driver name. For example, `ojdbc8.jar` is `ojdbc8_g.jar`. Configure the debugging driver by specifying the `library` subelement within the `jdbcDriver` element. The `library` subelement defines the path to the debugging driver JAR file.
+Prior to Oracle 23c, Oracle provided two different drivers, one for production and another for debugging purposes. The production driver does not produce any trace, so you need to download and replace your production driver with the debugging driver. The debugging driver has `_g` in the driver name. For example, `ojdbc8.jar` is `ojdbc8_g.jar`. Configure the debugging driver by specifying the `library` subelement within the `jdbcDriver` element. The `library` subelement defines the path to the debugging driver JAR file.
 
 After Oracle 23c there are no `_g` drivers and diagnotic trace is provided in the base JDBC driver.
 

--- a/modules/ROOT/pages/jdbc-tracing.adoc
+++ b/modules/ROOT/pages/jdbc-tracing.adoc
@@ -179,16 +179,18 @@ The Microsoft SQL Server DataDirect driver does not support the `java.util.loggi
 [#Oracle]
 === Oracle
 
-Oracle provides two different drivers, one for production and another for debugging purposes. The production driver does not produce any trace, so you need to download and replace your production driver with the debugging driver. The debugging driver has `_g` in the driver name. For example, `ojdbc8.jar` is `ojdbc8_g.jar`. Configure the debugging driver by specifying the `library` subelement within the `jdbcDriver` element. The `library` subelement defines the path to the debugging driver JAR file.
+Prior to Oracle 23c Oracle provided two different drivers, one for production and another for debugging purposes. The production driver does not produce any trace, so you need to download and replace your production driver with the debugging driver. The debugging driver has `_g` in the driver name. For example, `ojdbc8.jar` is `ojdbc8_g.jar`. Configure the debugging driver by specifying the `library` subelement within the `jdbcDriver` element. The `library` subelement defines the path to the debugging driver JAR file.
 
-The Oracle driver supports the `java.util.logging` library. The driver uses the `oracle` package name for trace specification. The following `server.xml` file example shows you how to configure the Oracle debugging driver and enable trace.
+After Oracle 23c there are no `_g` drivers and diagnotic trace is provided in the base JDBC driver.
+
+The Oracle JDBC and Oracle JDBC debug drivers support the `java.util.logging` library. The driver uses the `oracle` package name for trace specification. The following `server.xml` file example shows you how to configure the Oracle debugging driver and enable trace.
 
 [source, xml]
 ----
 <logging traceSpecification="*=info:RRA=all:oracle=all" />
 <jdbcDriver id="oracleDriver">
   <library id="oracleDebug">
-      <file name="path_to_oracle_driver/ojdbcX_g.jar"/>
+      <file name="path_to_oracle_driver/ojdbcX[_g].jar"/>
   </library>
 </jdbcDriver>
 ----
@@ -210,7 +212,7 @@ The following `server.xml` file example shows you how to configure the Oracle de
 ----
 <jdbcDriver id="oracleDriver">
   <library id="oracleDebug">
-      <file name="path_to_oracle_driver/ojdbcX_g.jar"/>
+      <file name="path_to_oracle_driver/ojdbcX[_g].jar"/>
   </library>
 </jdbcDriver>
 ----

--- a/modules/ROOT/pages/jdbc-tracing.adoc
+++ b/modules/ROOT/pages/jdbc-tracing.adoc
@@ -181,7 +181,7 @@ The Microsoft SQL Server DataDirect driver does not support the `java.util.loggi
 
 Prior to Oracle 23c, Oracle provided two different drivers, one for production and another for debugging purposes. The production driver does not produce any trace, so you need to download and replace your production driver with the debugging driver. The debugging driver has `_g` in the driver name. For example, `ojdbc8.jar` is `ojdbc8_g.jar`. Configure the debugging driver by specifying the `library` subelement within the `jdbcDriver` element. The `library` subelement defines the path to the debugging driver JAR file.
 
-After Oracle 23c there are no `_g` drivers and diagnotic trace is provided in the base JDBC driver.
+In Oracle 23c and later, Oracle no longer provides the `_g` drivers and diagnostic trace is provided in the base JDBC driver.
 
 The Oracle JDBC and Oracle JDBC debug drivers support the `java.util.logging` library. The driver uses the `oracle` package name for trace specification. The following `server.xml` file example shows you how to configure the Oracle debugging driver and enable trace.
 


### PR DESCRIPTION
Oracle 23c no longer has an ojdbcX_g variant. 
Update our tracing docs to align with this change.