### PR TITLE
Clarify properties for Oracle jdbc driver tracing

### DIFF
--- a/modules/ROOT/pages/jdbc-tracing.adoc
+++ b/modules/ROOT/pages/jdbc-tracing.adoc
@@ -228,7 +228,7 @@ Add the following required properties to the `jvm.options` file to enable a new 
 -DoracleLogPackageName=<package-to-trace>
 ----
 
-- `oracle.jdbc.Trace` : Enables global log handler for the Oracle JDBC driver
+- `oracle.jdbc.Trace` : This property enables the global log handler for the Oracle JDBC driver.
 - `oracleLogFileName` : The file name for custom logging. For example, oracle.log
 - `oracleLogPackageName` : The package to trace. For example; oracle, oracle.jdbc, or oracle.net
 

--- a/modules/ROOT/pages/jdbc-tracing.adoc
+++ b/modules/ROOT/pages/jdbc-tracing.adoc
@@ -195,10 +195,11 @@ The Oracle JDBC and Oracle JDBC debug drivers support the `java.util.logging` li
 </jdbcDriver>
 ----
 
-Add the following option to the `jvm.options` file to ensure that all trace is produced.
+For Oracle 23c and later, add the following option to the `jvm.options` file to enable trace.
+To avoid the performance impact of logging trace strings the Oracle JDBC driver will not log trace without this property set to true.
 [source, txt]
 ----
--Doracle.jdbc.Trace=true
+-Doracle.jdbc.diagnostic.enableLogging=true
 ----
 
 [#OracleCustom]
@@ -226,6 +227,10 @@ Add the following required properties to the `jvm.options` file to enable a new 
 -DoracleLogFileName=<your-log-name>.log
 -DoracleLogPackageName=<package-to-trace>
 ----
+
+- `oracle.jdbc.Trace` : Enables global log handler for the Oracle JDBC driver
+- `oracleLogFileName` : The file name for custom logging. For example, oracle.log
+- `oracleLogPackageName` : The package to trace. For example; oracle, oracle.jdbc, or oracle.net
 
 You can also customize the configured trace in the `jvm.options` file by using optional properties. 
 

--- a/modules/ROOT/pages/jdbc-tracing.adoc
+++ b/modules/ROOT/pages/jdbc-tracing.adoc
@@ -196,7 +196,7 @@ The Oracle JDBC and Oracle JDBC debug drivers support the `java.util.logging` li
 ----
 
 For Oracle 23c and later, add the following option to the `jvm.options` file to enable trace.
-To avoid the performance impact of logging trace strings the Oracle JDBC driver will not log trace without this property set to true.
+To avoid the performance impact of logging trace strings, the Oracle JDBC driver does not log trace unless this property is set to true.
 [source, txt]
 ----
 -Doracle.jdbc.diagnostic.enableLogging=true

--- a/modules/ROOT/pages/jdbc-tracing.adoc
+++ b/modules/ROOT/pages/jdbc-tracing.adoc
@@ -229,7 +229,7 @@ Add the following required properties to the `jvm.options` file to enable a new 
 ----
 
 - `oracle.jdbc.Trace` : This property enables the global log handler for the Oracle JDBC driver.
-- `oracleLogFileName` : The file name for custom logging. For example, oracle.log
+- `oracleLogFileName` : This property specifies the file name for custom logging. For example, `oracle.log`.
 - `oracleLogPackageName` : The package to trace. For example; oracle, oracle.jdbc, or oracle.net
 
 You can also customize the configured trace in the `jvm.options` file by using optional properties. 

--- a/modules/ROOT/pages/jdbc-tracing.adoc
+++ b/modules/ROOT/pages/jdbc-tracing.adoc
@@ -230,7 +230,7 @@ Add the following required properties to the `jvm.options` file to enable a new 
 
 - `oracle.jdbc.Trace` : This property enables the global log handler for the Oracle JDBC driver.
 - `oracleLogFileName` : This property specifies the file name for custom logging. For example, `oracle.log`.
-- `oracleLogPackageName` : The package to trace. For example; oracle, oracle.jdbc, or oracle.net
+- `oracleLogPackageName` : This property specifies the package to trace. For example, `oracle`, `oracle.jdbc`, or `oracle.net`
 
 You can also customize the configured trace in the `jvm.options` file by using optional properties. 
 


### PR DESCRIPTION
@dmuelle - Hopefully this is the last update for a while.

- oracle.jdbc.Trace - not necessary for normal logging prior to Oracle 23c
- oracle.jdbc.diagnostic.enableLoggin - is required for logging for Oracle 23c and later
- Describe properties for custom logging better.

Tested configuration https://github.com/OpenLiberty/open-liberty/pull/29246