### PR TITLE
edits

### DIFF
--- a/modules/ROOT/pages/microprofile-telemetry.adoc
+++ b/modules/ROOT/pages/microprofile-telemetry.adoc
@@ -28,21 +28,27 @@ The following sections explain how to prepare your Open Liberty runtime and appl
 [#global]
 == Enabling MicroProfile Telemetry for Open Liberty
 
-To enable MicroProfile Telemetry in your Open Liberty runtime, you must add the MicroProfile Telemetry feature to your `server.xml` file and enable the OpenTelemetry SDK.OpenTelemetry is disabled by default. Depending on your needs, you can configure OpenTelemetry SDK instances at the runtime level or the application level.
+OpenTelemetry is disabled by default. Depending on your needs, you can configure OpenTelemetry SDK instances at the runtime level or the application level.
 
 Runtime-level configuration::
 Runtime-level configuration collects and emits telemetry from the runtime and all applications. However, this configuration is preferable when you are running a single application per Liberty because all telemetry emitted is labeled as coming from the same service.
-
++
 You can configure your runtime instance in a few different sources, including your `jvm.options`, `bootstrap.properties`, or `server.env` files. You do not need to modify your application configuration to configure your runtime instance.
 
 Application-level configuration::
 Configuring application-level OpenTelemetry instances gives you more fine-grained control over the data you collect for each application. This option also supports compatibility with earlier versions of MicroProfile Telemetry, which created only application SDK instances. Runtime-level data is not collected or emitted with application-level instances.
-
++
 You can configure your application-level OpenTelemetry instances in the applications `microprofile-config.properties` files or the `appProperties` attribute in the `server.xml` file for each application. When you create application-level instances, any system and server environment properties overwrite your application-level configuration. For more information about configuration sources and their ordinal values, see xref:external-configuration.adoc#default[Default configuration sources].
+
+
+
+To enable MicroProfile Telemetry in your Open Liberty runtime, you must add the MicroProfile Telemetry feature to your `server.xml` file and enable the OpenTelemetry SDK.
 
 . Enable the feature:mpTelemetry[display=MicroProfile Telemetry] feature in your `server.xml` file. To export metrics or logs, you must enable `mpTelemetry-2.0` or later.
 
-. To enable the generation of traces, metrics, and logs, set the `otel.sdk.disabled=false` property at the runtime level or the application level.
+. Set the `otel.sdk.disabled=false` property at the runtime level or the application level.
++
+At runtime initialization, if the `otel.sdk.disabled` property is set to false, the runtime-level OpenTelemetry SDK instance is created. If the runtime instance is not enabled and `otel.sdk.disabled=false` is specified at the application level, an application-level instance is created during application initialization.
 
 .. To enable the OpenTelemetry SDK at the runtime level, set the `otel.sdk.disabled=false property` as a system property, for example, in the `bootstrap.properties` file:
 +
@@ -72,10 +78,10 @@ otel.service.name=A2
 ----
 +
 This configuration creates all telemetry from App1 with the service name A1, and from App2 with the service name A2. It omits all runtime-level telemetry.
+
+.. Optionally, use a combination of application-level and runtime-level configuration.
 +
-At runtime initialization, if the `otel.sdk.disabled` property is set to false, the runtime-level OpenTelemetry SDK instance is created. If the runtime instance is not enabled and `otel.sdk.disabled=false` is specified at the application level, an application-level instance is created during application initialization.
-+
-You can also use a combination of application-level and runtime-level configuration. Regardless of whether a runtime instance is created, any configuration in the system properties and server environment variables takes precedence over application-level configuration. Therefore, you can configure common application configuration at the runtime level in the server environment variables or system properties and make application-specific changes in your application configuration.
+Regardless of whether a runtime instance is created, any configuration in the system properties and server environment variables takes precedence over application-level configuration. Therefore, you can configure common application configuration at the runtime level in the server environment variables or system properties and make application-specific changes in your application configuration.
 +
 For example, you can set the OpenTelemetry exporter at the runtime-level in the `bootstrap.properties` file:
 +


### PR DESCRIPTION
At runtime initialization, if the `otel.sdk.disabled` property is set to false, the runtime-level OpenTelemetry SDK instance is created. If the runtime instance is not enabled and `otel.sdk.disabled=false` is specified at the application level, an application-level instance is created during application initialization.