### PR TITLE
add mptel to fault tolerence metrics

### DIFF
--- a/modules/ROOT/pages/mptelemetry-metrics-list.adoc
+++ b/modules/ROOT/pages/mptelemetry-metrics-list.adoc
@@ -19,6 +19,8 @@
 :mp-4-0: feature:mpMetrics-4.0[display=MicroProfile Metrics 4.0]
 :mp-5-0: feature:mpMetrics-5.0[display=MicroProfile Metrics 5.0]
 :mp-ft-3-0: feature:mpFaultTolerance-3.0[display=MicroProfile Fault Tolerance 3.0]
+:mp-tel-2-0: feature:mpTelemetry-2.0[display=MicroProfile Telemetry 2.0]
+:mp-tel-2-0-ft-4-1: feature:mpTelemetry-2.0[display=MicroProfile Telemetry 2.0] and feature:mpFaultTolerance-4.1[display=MicroProfile Fault Tolerance 4.1]
 :connector-metric-features: feature:mpMetrics[display=MicroProfile Metrics] and feature:mpReactiveMessaging[display=MicroProfile Reactive Messaging 3.0]
 :base-metric-features: feature:mpMetrics[display=MicroProfile Metrics]
 :vendor-metric-features: feature:mpMetrics[display=MicroProfile Metrics]
@@ -303,6 +305,109 @@ The **Version introduced** column specifies the minimum version of the feature t
 | n/a
 | feature:mpTelemetry[display=MicroProfile Telemetry]
 | feature:mpTelemetry-2.0[display=MicroProfile Telemetry 2.0]
+
+| ft.invocations.total
+| * `method` - the fully qualified method name
+* `result = [valueReturned\|exceptionThrown]` - whether the invocation returned a value or threw an exception
+* `fallback = [applied\|notApplied\|notDefined]` - `applied` if fallback was used, `notApplied` if a fallback is configured but was not used, `notDefined` if a fallback is not configured.
+| The number of times the method was called. This metric is a `LongCounter`.
+| n/a
+| {mp-tel-2-0-ft-4-1}
+| {mp-tel-2-0}
+
+| ft.retry.calls.total
+| * `method` - the fully qualified method name,
+* `retried = [true\|false]` - whether any retries occurred
+* `retryResult = [valueReturned\|exceptionNotRetryable\|maxRetriesReached\|maxDurationReached]` - the reason that last attempt to call the method was not retried.
+| The number of times the retry logic was run. This value is always equal to once per method call. This metric is a `LongCounter`.
+| n/a
+| {mp-tel-2-0-ft-4-1}
+| {mp-tel-2-0}
+
+| ft.retry.retries.total
+| `method` - the fully qualified method name
+| The number of times the method was retried. This metric is a `LongCounter`.
+| `method` - the fully qualified method name
+| {mp-tel-2-0-ft-4-1}
+| {mp-tel-2-0}
+
+| ft.timeout.calls.total
+| * `method` - the fully qualified method name
+* `timedOut = [true\|false]` - whether the method call timed out
+| The number of times the timeout logic was run. This value is typically equal to once per method call. However, it might be zero if the circuit breaker prevents execution or more than once per method call if the method is retried. This metric is a `LongCounter`.
+| n/a
+| {mp-tel-2-0-ft-4-1}
+| {mp-tel-2-0}
+
+| ft.timeout.executionDuration
+| `method` - the fully qualified method name
+| Histogram of execution times for the method. This metric is a `DoubleHistogram`
+| n/a
+| {mp-tel-2-0-ft-4-1}
+| {mp-tel-2-0}
+
+| ft.circuitbreaker.calls.total
+| * `method` - the fully qualified method name,
+    * `circuitBreakerResult = [success\|failure\|circuitBreakerOpen]` - the result of the method call, as considered by the circuit breaker according to the rules in https://download.eclipse.org/microprofile/microprofile-fault-tolerance-4.0.2/microprofile-fault-tolerance-spec-4.0.2.html#circuit-breaker-success-failure[Configuring which exceptions are considered a failure]
+        ** `success` - the method ran and was successful
+        **  `failure` - the method ran and failed
+        ** `circuitBreakerOpen` - the method did not run because the circuit breaker was in open or half-open state
+
+| The number of times the circuit breaker logic was run. This value is typically equal to once per method call, but might be more than once if the method is retried. This metric is a `LongCounter`.
+| n/a
+| {mp-tel-2-0-ft-4-1}
+| {mp-tel-2-0}
+
+| ft.circuitbreaker.state.total
+| * `method` - the fully qualified method name
+ * `state = [open\|closed\|halfOpen]` - the circuit breaker state
+| Amount of time the circuit breaker spent in each state. This metric is a `LongCounter`.
+| n/a
+| {mp-tel-2-0-ft-4-1}
+| {mp-tel-2-0}
+
+| ft.circuitbreaker.opened.total
+| `method` - the fully qualified method name
+| Number of times the circuit breaker moved from closed state to open state. This metric is a `LongCounter`.
+| n/a
+| {mp-tel-2-0-ft-4-1}
+| {mp-tel-2-0}
+
+| ft.bulkhead.calls.total
+| * `method` - the fully qualified method name
+* `bulkheadResult = [accepted\|rejected]` - whether the bulkhead allowed the method call to run
+| The number of times the bulkhead logic was run. This value is typically equal to once per method call. However, it might be zero if the circuit breaker prevents execution or more than once per method call if the method is retried. This metric is a `LongCounter`.
+| n/a
+| {mp-tel-2-0-ft-4-1}
+| {mp-tel-2-0}
+
+| ft.bulkhead.executionsRunning
+| `method` - the fully qualified method name
+| Number of currently running executions. This metric is a `LongUpDownCounter`.
+| n/a
+| {mp-tel-2-0-ft-4-1}
+| {mp-tel-2-0}
+
+| ft.bulkhead.executionsWaiting
+| `method` - the fully qualified method name
+| Number of executions that are currently waiting in the queue. This metric is a `LongUpDownCounter`.
+| n/a
+| {mp-tel-2-0-ft-4-1}
+| {mp-tel-2-0}
+
+| ft.bulkhead.runningDuration
+| `method` - the fully qualified method name
+| Histogram of the time that method executions spent running. This metric is a `DoubleHistogram`.
+| n/a
+| {mp-tel-2-0-ft-4-1}
+| {mp-tel-2-0}
+
+| ft.bulkhead.waitingDuration
+| `method` - the fully qualified method name
+| Histogram of the time that method executions spent waiting in the queue. This metric is a `DoubleHistogram`.
+| n/a
+| {mp-tel-2-0-ft-4-1}
+| {mp-tel-2-0}
 
 |===
 


### PR DESCRIPTION
Update the metric list so that FT metrics also say they can be used with Open Telemetry 2.0

Resolves #7581