### PR TITLE
Fix typos in virtual host config

### DIFF
--- a/modules/ROOT/pages/virtual-hosts.adoc
+++ b/modules/ROOT/pages/virtual-hosts.adoc
@@ -100,7 +100,7 @@ To associate your application with this virtual host, you must add a reference t
     xmlns="http://websphere.ibm.com/xml/ns/javaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://websphere.ibm.com/xmk/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-bnd_1_0.xsd"
-    version="1.0" />
+    version="1.0" >
 
     <virtual-host name="proxiedRequests" />
 
@@ -121,7 +121,7 @@ In the following example, the `localHostOnly` HTTP endpoint specifies that ports
     <hostAlias>*:9444</hostAlias>
 </virtualHost>
 
-</virtualHost id="proxiedRequests">
+<virtualHost id="proxiedRequests">
     <hostAlias>*:9080</hostAlias>
     <hostAlias>*:9443</hostAlias>
     <hostAlias>external.host.name:80</hostAlias>


### PR DESCRIPTION
There are two typos in xml syntax in virtual host config which means the examples are not valid xml.

Fixes #7773