### PR TITLE
Update security-vulnerabilities.adoc for 25002

### DIFF
--- a/modules/ROOT/pages/security-vulnerabilities.adoc
+++ b/modules/ROOT/pages/security-vulnerabilities.adoc
@@ -26,7 +26,14 @@ The `CWWKF0012I` message uses the word "installed", but it lists features that a
 
 [cols="6*"]
 |===
-|CVE |CVSS score by X-Force® |Vulnerability assessment |Versions affected |Version fixed |Notes
+|CVE |CVSS score |Vulnerability assessment |Versions affected |Version fixed |Notes
+
+|https://www.cve.org/CVERecord?id=CVE-2024-47535[CVE-2024-47535]
+|5.5
+|Denial of service
+|21.0.0.2 - 25.0.0.1
+|25.0.0.2
+|Affects the feature:grpc-1.0[] and feature:grpcClient-1.0[] features
 
 |https://www.cve.org/CVERecord?id=CVE-2024-40094[CVE-2024-40094]
 |5.3


### PR DESCRIPTION
This PR is for updates to the Security vulnerability list for 25002.
This PR also updates the CVSS score column heading to remove reference to X-Force since starting in 2025, the source of the CVSS score may vary as discussed in the customer facing article on Overview of Security bulletins at https://www.ibm.com/support/pages/ibm-security-bulletin-overview:

CVSS Source: The company or entity providing the Common Vulnerability Scoring System (CVSS) information. Sources: CISA-ADP, CVE Numbering Authority (CNA), NVD, X-Force