### PR TITLE
#7816 Updates involving FIPS 140-3

### DIFF
--- a/modules/ROOT/pages/enable-fips.adoc
+++ b/modules/ROOT/pages/enable-fips.adoc
@@ -13,9 +13,10 @@
 The Federal Information Processing Standard (FIPS) 140-2 is a US government security standard for cryptographic modules. Although FIPS compliance is determined by your underlying Java virtual machine (JVM), you can enable Open Liberty to run on a FIPS-compliant JVM.
 
 FIPS enablement is important for many users, particularly if you work for or with US government agencies. Running your Open Liberty servers on a FIPS-compliant JVM helps ensure that only FIPS-certified cryptography is used when an application uses Java security libraries or APIs. FIPS-compliant JVM options for Open Liberty are link:https://www.ibm.com/docs/en/sdk-java-technology/8[IBM SDK, Java Technology Edition] or link:https://developer.ibm.com/articles/explore-options-for-downloading-ibm-semeru-runtimes[IBM Semeru Runtimes].
-If you want to use FIPS 140-3, you must use the IBM SDK for Java 8.0.8.30 or later. Then complete the steps in the WebSphere Liberty documentation.
 
-For more information about enabling FIPS for Liberty with the IBM SDK, Java Technology Edition, see link:https://www.ibm.com/docs/en/was-liberty/nd?topic=liberty-setting-up-fips-compliance[Setting up Liberty for FIPS compliance] in the WebSphere Liberty documentation. The configuration is the same for both WebSphere Liberty and Open Liberty. This option is available only for Java SE 8. For Java SE 11 or later, use IBM Semeru Runtimes.
+To enable FIPS for Liberty with the IBM SDK, Java Technology Edition, see link:https://www.ibm.com/docs/en/was-liberty/nd?topic=liberty-setting-up-fips-compliance[Setting up Liberty for FIPS compliance] in the WebSphere Liberty documentation. The configuration is the same for both WebSphere Liberty and Open Liberty. This option is available only for Java SE 8. For Java SE 11 or later, use IBM Semeru Runtimes.
+
+If you want to use FIPS 140-3, you must use the IBM SDK, Java Technology Edition, version 8.0.8.30 or later. Then complete the steps in the WebSphere Liberty documentation.
 
 == Enable FIPS for Open Liberty on IBM Semeru Runtimes
 

--- a/modules/ROOT/pages/enable-fips.adoc
+++ b/modules/ROOT/pages/enable-fips.adoc
@@ -13,8 +13,7 @@
 The Federal Information Processing Standard (FIPS) 140-2 is a US government security standard for cryptographic modules. Although FIPS compliance is determined by your underlying Java virtual machine (JVM), you can enable Open Liberty to run on a FIPS-compliant JVM.
 
 FIPS enablement is important for many users, particularly if you work for or with US government agencies. Running your Open Liberty servers on a FIPS-compliant JVM helps ensure that only FIPS-certified cryptography is used when an application uses Java security libraries or APIs. FIPS-compliant JVM options for Open Liberty are link:https://www.ibm.com/docs/en/sdk-java-technology/8[IBM SDK, Java Technology Edition] or link:https://developer.ibm.com/articles/explore-options-for-downloading-ibm-semeru-runtimes[IBM Semeru Runtimes].
-
-NOTE: To enable FIPS 140-3, you must use IBM SDK for Java 8.0.8.30 or later.
+If you want to use FIPS 140-3, you must use the IBM SDK for Java 8.0.8.30 or later. Then complete the steps in the WebSphere Liberty documentation.
 
 For more information about enabling FIPS for Liberty with the IBM SDK, Java Technology Edition, see link:https://www.ibm.com/docs/en/was-liberty/nd?topic=liberty-setting-up-fips-compliance[Setting up Liberty for FIPS compliance] in the WebSphere Liberty documentation. The configuration is the same for both WebSphere Liberty and Open Liberty. This option is available only for Java SE 8. For Java SE 11 or later, use IBM Semeru Runtimes.
 

--- a/modules/ROOT/pages/enable-fips.adoc
+++ b/modules/ROOT/pages/enable-fips.adoc
@@ -14,6 +14,8 @@ The Federal Information Processing Standard (FIPS) 140-2 is a US government secu
 
 FIPS enablement is important for many users, particularly if you work for or with US government agencies. Running your Open Liberty servers on a FIPS-compliant JVM helps ensure that only FIPS-certified cryptography is used when an application uses Java security libraries or APIs. FIPS-compliant JVM options for Open Liberty are link:https://www.ibm.com/docs/en/sdk-java-technology/8[IBM SDK, Java Technology Edition] or link:https://developer.ibm.com/articles/explore-options-for-downloading-ibm-semeru-runtimes[IBM Semeru Runtimes].
 
+NOTE: To enable FIPS 140-3, you must use IBM SDK for Java 8.0.8.30 or later.
+
 For more information about enabling FIPS for Liberty with the IBM SDK, Java Technology Edition, see link:https://www.ibm.com/docs/en/was-liberty/nd?topic=liberty-setting-up-fips-compliance[Setting up Liberty for FIPS compliance] in the WebSphere Liberty documentation. The configuration is the same for both WebSphere Liberty and Open Liberty. This option is available only for Java SE 8. For Java SE 11 or later, use IBM Semeru Runtimes.
 
 == Enable FIPS for Open Liberty on IBM Semeru Runtimes

--- a/modules/reference/pages/command/auditUtility-auditReader.adoc
+++ b/modules/reference/pages/command/auditUtility-auditReader.adoc
@@ -18,8 +18,6 @@
 The `auditUtility auditReader` command decrypts and unsigns an audit log that is encrypted, signed, or both.
 The command must specify the locations of the audit log and the output file.
 
-The `auditUtility auditReader` command use updated algorithms when FIPS 140-3 is enabled. For more information about FIPS 140-3, see xref:enable-fips.adoc[Run FIPS-compliant applications on Open Liberty].
-
 == Usage examples
 
 The following example demonstrates the proper syntax to decrypt an audit log that is encrypted:

--- a/modules/reference/pages/command/auditUtility-auditReader.adoc
+++ b/modules/reference/pages/command/auditUtility-auditReader.adoc
@@ -18,6 +18,8 @@
 The `auditUtility auditReader` command decrypts and unsigns an audit log that is encrypted, signed, or both.
 The command must specify the locations of the audit log and the output file.
 
+The `auditUtility auditReader` command use updated algorithms when FIPS 140-3 is enabled. For more information about FIPS 140-3, see xref:enable-fips.adoc[Run FIPS-compliant applications on Open Liberty].
+
 == Usage examples
 
 The following example demonstrates the proper syntax to decrypt an audit log that is encrypted:

--- a/modules/reference/pages/command/securityUtility-createLTPAKeys.adoc
+++ b/modules/reference/pages/command/securityUtility-createLTPAKeys.adoc
@@ -17,6 +17,14 @@
 The `securityUtility createLTPAKeys` command creates a set of LTPA keys for use by the server, or that can be shared with multiple servers.
 If no server or file is specified, an `ltpa.keys` file is created in the current working directory.
 
+To enable the `securityUtility` tool to create LTPA keys with the `createLTPAKeys` command on FIPS 140-3 enabled servers, export the following environment variable before you run the tool:
+
+----
+export JVM_ARGS="-Xenablefips140-3 -Dcom.ibm.jsse2.usefipsprovider=true -Dcom.ibm.jsse2.usefipsProviderName=IBMJCEPlusFIPS"
+----
+
+For more information about FIPS 140-3, see xref:enable-fips.adoc[Run FIPS-compliant applications on Open Liberty].
+
 == Usage example
 
 Create LTPA keys with the `mypassword` password that is encrypted with Advanced Encryption Standard (AES) encryption:

--- a/modules/reference/pages/command/securityUtility-encode.adoc
+++ b/modules/reference/pages/command/securityUtility-encode.adoc
@@ -27,14 +27,6 @@ If your password includes special characters, you must escape each special chara
 
 For more information about limits to password encryption, see xref:ROOT:password-encryption.adoc[Password encryption limitations].
 
-To enable the `securityUtility` tool to create LTPA keys with the `createLTPAKeys` command on FIPS 140-3 enabled servers, export the following environment variable before you run the tool:
-
-----
-export JVM_ARGS="-Xenablefips140-3 -Dcom.ibm.jsse2.usefipsprovider=true -Dcom.ibm.jsse2.usefipsProviderName=IBMJCEPlusFIPS"
-----
-
-For more information on FIPS 140-3, see xref:enable-fips.adoc[Run FIPS-compliant applications on Open Liberty]. 
-
 == Usage examples
 
 Encrypt a password with Advanced Encryption Standard (AES) encryption. After you enter this command, interactive mode prompts you for the password that you want to encrypt:

--- a/modules/reference/pages/command/securityUtility-encode.adoc
+++ b/modules/reference/pages/command/securityUtility-encode.adoc
@@ -66,7 +66,7 @@ The `aes` type uses AES-256 encryption.
 {empty} +
 You can use the `hash` encoding type to encode passwords for a xref:ROOT:user-registries-application-security.adoc[basic user registry] or passwords for the xref:config/quickStartSecurity.adoc[quickStartSecurity element].
 
-When FIPS 140-3 is enabled, both `aes` encryption and `hash` use enhanced algorithms to encrypt and encode strings. Strings that were encrypted or encode with older algorithms fail.
+When FIPS 140-3 is enabled, both the `aes` and `hash` options use enhanced algorithms to encrypt and encode strings. Strings that were encrypted or encoded with these options before the algorithms were enhanced might fail in FIPS 140-3 environments.
 
 |--key=_encryption_key_
 |Specifies the key to use when you encode with AES encryption.

--- a/modules/reference/pages/command/securityUtility-encode.adoc
+++ b/modules/reference/pages/command/securityUtility-encode.adoc
@@ -27,6 +27,14 @@ If your password includes special characters, you must escape each special chara
 
 For more information about limits to password encryption, see xref:ROOT:password-encryption.adoc[Password encryption limitations].
 
+To enable the `securityUtility` tool to create LTPA keys with the `createLTPAKeys` command on FIPS 140-3 enabled servers, export the following environment variable before you run the tool:
+
+----
+export JVM_ARGS="-Xenablefips140-3 -Dcom.ibm.jsse2.usefipsprovider=true -Dcom.ibm.jsse2.usefipsProviderName=IBMJCEPlusFIPS"
+----
+
+For more information on FIPS 140-3, see xref:enable-fips.adoc[Run FIPS-compliant applications on Open Liberty]. 
+
 == Usage examples
 
 Encrypt a password with Advanced Encryption Standard (AES) encryption. After you enter this command, interactive mode prompts you for the password that you want to encrypt:
@@ -65,6 +73,8 @@ The `aes` type uses AES-256 encryption.
 {empty} +
 {empty} +
 You can use the `hash` encoding type to encode passwords for a xref:ROOT:user-registries-application-security.adoc[basic user registry] or passwords for the xref:config/quickStartSecurity.adoc[quickStartSecurity element].
+
+When FIPS 140-3 is enabled, both `aes` encryption and `hash` use enhanced algorithms to encrypt and encode strings. Strings that were encrypted or encode with older algorithms fail.
 
 |--key=_encryption_key_
 |Specifies the key to use when you encode with AES encryption.


### PR DESCRIPTION
#7816 mades edits to the OL documentation, pointing out that to enable FIPS 140-3, IBM SDK for Java 8 must be enabled.