### PR TITLE
vm.memory.pool.name should be jvm.memory.pool.name

### DIFF
--- a/modules/ROOT/pages/mptelemetry-metrics-list.adoc
+++ b/modules/ROOT/pages/mptelemetry-metrics-list.adoc
@@ -323,7 +323,8 @@ The **Version introduced** column specifies the minimum version of the feature t
 | feature:mpTelemetry-2.0[display=MicroProfile Telemetry 2.0]
 
 | jvm.memory.used
-| vm.memory.pool.name="<pool_name>" , -jvm.memory.type=<memory_type>
+| * jvm.memory.pool.name="<pool_name>"
+* jvm.memory.type=<memory_type>
 | Measure of memory used. This metric is an `UpDownCounter` counter. /(bytes)
 | n/a
 | feature:mpTelemetry[display=MicroProfile Telemetry]


### PR DESCRIPTION
See https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmmemoryused