### PR TITLE
Update java 8 date

### DIFF
--- a/modules/ROOT/pages/java-se.adoc
+++ b/modules/ROOT/pages/java-se.adoc
@@ -45,7 +45,7 @@ The following table lists the Java SE versions that Open Liberty supports and pr
 
 |8
 |Yes
-|29.0.0.2
+|29.0.0.1
 |https://developer.ibm.com/languages/java/semeru-runtimes/downloads/?version=8[IBM Semeru 8]
 |https://adoptium.net/?variant=openjdk8&jvmVariant=hotspot[Eclipse Temurin 8]
 |


### PR DESCRIPTION
There was some confusion between 29.0.0.1 being the last to support Java 8 and or the one to remove it and it was documented based on incorrectly thinking it was the last to support Java 8. Fixing to correctly note Java 8 will not be supported in 29.0.0.1