### PR TITLE
Document AES password encryption for featureUtility

### DIFF
--- a/modules/reference/pages/command/featureUtility-commands.adoc
+++ b/modules/reference/pages/command/featureUtility-commands.adoc
@@ -132,6 +132,26 @@ remoteRepo2.user=operator
 remoteRepo2.password={aes}KM8dhwcv892Ss1sawu9R+
 ----
 
+=== Encrypt repository passwords
+
+For security, passwords in the `featureUtility.properties` file should be encrypted using the AES encryption algorithm. Use the `securityUtility encode` command to encrypt passwords before adding them to the properties file.
+
+To encrypt a password, run the following command:
+
+----
+securityUtility encode --encoding=aes myPassword
+----
+
+The command outputs the encrypted password in the format `{aes}encryptedValue`. Copy this encrypted value and use it as the password in your `featureUtility.properties` file, as shown in the previous example.
+
+If you use an unencrypted password in the `featureUtility.properties` file, the `featureUtility` commands display the following warning message:
+
+----
+CWWKF1374E: The password is not encrypted. Password must be encrypted using the securityUtility command with the AES cryptography algorithm as the recommended --encoding option.
+----
+
+For more information about the `securityUtility encode` command, see xref:command/securityUtility-encode.adoc[securityUtility encode].
+
 
 == Disable Maven Central fallback
 

--- a/modules/reference/pages/command/featureUtility-commands.adoc
+++ b/modules/reference/pages/command/featureUtility-commands.adoc
@@ -82,6 +82,10 @@ a|Configures the outbound HTTP proxy.
 |`proxyHost`, `proxyPort`, `proxyUser`, and `proxyPassword`
 a|Configures the outbound HTTPS proxy.
 
+|`WLP_AES_ENCRYPTION_KEY`
+|`wlp.password.encryption.key` or `wlp.aes.encryption.key`
+|Specifies a custom AES encryption key for decrypting passwords. If not specified, featureUtility uses the Liberty default AES encryption key. featureUtility also automatically loads the encryption key from the `bootstrap.properties` or `server.env` file of the specified server when running `featureUtility installServerFeatures`.
+
 |===
 {empty} +
 
@@ -134,32 +138,7 @@ remoteRepo2.password={aes}KM8dhwcv892Ss1sawu9R+
 
 === Encrypt repository passwords
 
-For security, passwords in the `featureUtility.properties` file should be encrypted using the AES encryption algorithm. Use the `securityUtility encode` command to encrypt passwords before adding them to the properties file.
-
-To encrypt a password, run the following command:
-
-----
-securityUtility encode --encoding=aes myPassword
-----
-
-The command outputs the encrypted password in the format `{aes}encryptedValue`. Copy this encrypted value and use it as the password in your `featureUtility.properties` file, as shown in the previous example.
-
-If you use an unencrypted password in the `featureUtility.properties` file, the `featureUtility` commands display the following warning message:
-
-----
-CWWKF1374E: The password is not encrypted. Password must be encrypted using the securityUtility command with the AES cryptography algorithm as the recommended --encoding option.
-----
-
-
-=== Specify the AES encryption key
-
-By default, featureUtility uses the Liberty default AES encryption key to decrypt passwords. If you encrypted your password with a custom key, you must provide that key to featureUtility using one of the following methods:
-
-* Set the `WLP_AES_ENCRYPTION_KEY` environment variable.
-* Specify the `wlp.password.encryption.key` or `wlp.aes.encryption.key` property in the `featureUtility.properties` file.
-
-featureUtility also automatically loads the encryption key from the `bootstrap.properties` or `server.env` file of the specified server when running `featureUtility installServerFeatures`.
-For more information about the `securityUtility encode` command, see xref:command/securityUtility-encode.adoc[securityUtility encode].
+For security, passwords in the `featureUtility.properties` file should be encrypted. The AES encryption algorithm is recommended. Use the `securityUtility encode` command to encrypt passwords before adding them to the properties file. For more information, see xref:command/securityUtility-encode.adoc[securityUtility encode].
 
 
 == Disable Maven Central fallback

--- a/modules/reference/pages/command/featureUtility-commands.adoc
+++ b/modules/reference/pages/command/featureUtility-commands.adoc
@@ -150,6 +150,15 @@ If you use an unencrypted password in the `featureUtility.properties` file, the 
 CWWKF1374E: The password is not encrypted. Password must be encrypted using the securityUtility command with the AES cryptography algorithm as the recommended --encoding option.
 ----
 
+
+=== Specify the AES encryption key
+
+By default, featureUtility uses the Liberty default AES encryption key to decrypt passwords. If you encrypted your password with a custom key, you must provide that key to featureUtility using one of the following methods:
+
+* Set the `WLP_AES_ENCRYPTION_KEY` environment variable.
+* Specify the `wlp.password.encryption.key` or `wlp.aes.encryption.key` property in the `featureUtility.properties` file.
+
+featureUtility also automatically loads the encryption key from the `bootstrap.properties` or `server.env` file of the specified server when running `featureUtility installServerFeatures`.
 For more information about the `securityUtility encode` command, see xref:command/securityUtility-encode.adoc[securityUtility encode].
 
 


### PR DESCRIPTION
## Summary
Documents how to encrypt passwords using the `securityUtility encode` command with AES encryption for use in `featureUtility.properties`.

## Changes
- Added new section "Encrypt repository passwords" to the featureUtility commands reference page
- Explains how to use `securityUtility encode --encoding=aes` command
- Documents the CWWKF1374E warning message users will see with unencrypted passwords
- Links to securityUtility encode documentation

## Related
- Completes documentation for OpenLiberty/open-liberty#35200 
