### PR TITLE
Update link to expressionLanguage-6.0

### DIFF
--- a/modules/reference/pages/diff/jakarta-ee11-diff.adoc
+++ b/modules/reference/pages/diff/jakarta-ee11-diff.adoc
@@ -385,7 +385,7 @@ For more information, see the https://jakarta.ee/specifications/authorization/3.
 [#express]
 == Differences between Jakarta Expression Language 6.0 and 5.0
 
-The feature:el-6.0[display=Jakarta Expression Language 6.0] feature (`el-6.0`) introduces new resolvers for modern Java types and removes legacy methods.
+The feature:expressionLanguage-6.0[display=Jakarta Expression Language 6.0] feature (`expressionLanguage-6.0`) introduces new resolvers for modern Java types and removes legacy methods.
 
 === New additions
 


### PR DESCRIPTION
On this page, the link to the Jakarta Expression Language 6.0 documentation is broken due to the use of `el-6.0` instead of `expressionLanguage-6.0`.

Current link:
https://openliberty.io/docs/latest/reference/feature/el-6.0.html

What it should be:
https://openliberty.io/docs/latest/reference/feature/expressionLanguage-6.0.html