### PR TITLE
8498-RK-httpAccessLogging-not supported format tokens

### DIFF
--- a/modules/ROOT/pages/access-logging.adoc
+++ b/modules/ROOT/pages/access-logging.adoc
@@ -124,6 +124,9 @@ If no value is found, `0` is printed instead of `-`.
 |%U
 |The URL Path, not including the query string
 
+|%I or %O
+|Not supported. These Apache httpd tokens for bytes received and bytes sent including headers are not implemented in Liberty. Using them causes a startup FFDC (`IllegalArgumentException: Config: invalid format segment: %I` or `%O`). Use `%b` as the nearest alternative, which logs the response body size in bytes, excluding headers.
+
 |===
 
 Each option can be enclosed in quotation marks, but the quotation marks are not required. Unless otherwise noted, a value of `-` is printed for an option if the requested information cannot be obtained for that option.


### PR DESCRIPTION
8498-RK-httpAccessLogging-not supported format tokens

#8498